### PR TITLE
Fix spelling

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,9 @@ Unofficial integration for Zonneplan ONE solar inverter + Zonneplan connect
    - Gas last measured: `date`
 - Additional sensors:
    - Current Zonneplan Electricity tariff: `€/kWh` _(default disabled)_
-     - The full Electricity forcast is available as a forcast attribute of this sensor
+     - The full Electricity forecast is available as a forecast attribute of this sensor
    - Current Zonneplan Gas tariff: `€/m³` _(default disabled)_
-   - 8 hours forcast of Zonneplan Electricity tariff: `€/kWh` _(default disabled)_
+   - 8 hours forecast of Zonneplan Electricity tariff: `€/kWh` _(default disabled)_
    - Current elektricity usage
    - Sustainability score
 
@@ -52,7 +52,7 @@ Do you have [HACS](https://hacs.xyz/) installed?
 2. Create another folder `zonneplan_one` in the `custom_components` folder. Copy all files from `custom_components/zonneplan_one` into the `zonneplan_one` folder.
 
 ## Setup
-1. In Home Assitant click on `Configuration`
+1. In Home Assistant click on `Configuration`
 1. Click on `Integrations`
 1. Click on `+ Add integration`
 1. Search for and select `Zonneplan ONE`
@@ -64,7 +64,7 @@ Do you have [HACS](https://hacs.xyz/) installed?
 ## Setup Energy Dashboard
 
 #### Solar production
-`Zonneplan yield total` is what you’re panels produced
+`Zonneplan yield total` is what your panels produced
 
 #### Grid consumption  
 `Zonneplan P1 electricity consumption today` is what you used from the grid

--- a/custom_components/zonneplan_one/const.py
+++ b/custom_components/zonneplan_one/const.py
@@ -107,92 +107,92 @@ SENSOR_TYPES: dict[str, list[ZonneplanSensorEntityDescription]] = {
             icon="mdi:message-text-outline",
             entity_registry_enabled_default=True,
         ),
-        "forecast_tariff_1": ZonneplanSensorEntityDescription(
+        "forcast_tariff_1": ZonneplanSensorEntityDescription(
             key="summary_data.price_per_hour.25.price",
             name="Zonneplan forecast tariff hour 1",
             icon="mdi:cash",
             value_factor=0.0000001,
             native_unit_of_measurement=f"{CURRENCY_EURO}/{ENERGY_KILO_WATT_HOUR}",
         ),
-        "forecast_tariff_2": ZonneplanSensorEntityDescription(
+        "forcast_tariff_2": ZonneplanSensorEntityDescription(
             key="summary_data.price_per_hour.26.price",
             name="Zonneplan forecast tariff hour 2",
             icon="mdi:cash",
             value_factor=0.0000001,
             native_unit_of_measurement=f"{CURRENCY_EURO}/{ENERGY_KILO_WATT_HOUR}",
         ),
-        "forecast_tariff_3": ZonneplanSensorEntityDescription(
+        "forcast_tariff_3": ZonneplanSensorEntityDescription(
             key="summary_data.price_per_hour.27.price",
             name="Zonneplan forecast tariff hour 3",
             icon="mdi:cash",
             value_factor=0.0000001,
             native_unit_of_measurement=f"{CURRENCY_EURO}/{ENERGY_KILO_WATT_HOUR}",
         ),
-        "forecast_tariff_4": ZonneplanSensorEntityDescription(
+        "forcast_tariff_4": ZonneplanSensorEntityDescription(
             key="summary_data.price_per_hour.28.price",
             name="Zonneplan forecast tariff hour 4",
             icon="mdi:cash",
             value_factor=0.0000001,
             native_unit_of_measurement=f"{CURRENCY_EURO}/{ENERGY_KILO_WATT_HOUR}",
         ),
-        "forecast_tariff_5": ZonneplanSensorEntityDescription(
+        "forcast_tariff_5": ZonneplanSensorEntityDescription(
             key="summary_data.price_per_hour.29.price",
             name="Zonneplan forecast tariff hour 5",
             icon="mdi:cash",
             value_factor=0.0000001,
             native_unit_of_measurement=f"{CURRENCY_EURO}/{ENERGY_KILO_WATT_HOUR}",
         ),
-        "forecast_tariff_6": ZonneplanSensorEntityDescription(
+        "forcast_tariff_6": ZonneplanSensorEntityDescription(
             key="summary_data.price_per_hour.30.price",
             name="Zonneplan forecast tariff hour 6",
             icon="mdi:cash",
             value_factor=0.0000001,
             native_unit_of_measurement=f"{CURRENCY_EURO}/{ENERGY_KILO_WATT_HOUR}",
         ),
-        "forecast_tariff_7": ZonneplanSensorEntityDescription(
+        "forcast_tariff_7": ZonneplanSensorEntityDescription(
             key="summary_data.price_per_hour.31.price",
             name="Zonneplan forecast tariff hour 7",
             icon="mdi:cash",
             value_factor=0.0000001,
             native_unit_of_measurement=f"{CURRENCY_EURO}/{ENERGY_KILO_WATT_HOUR}",
         ),
-        "forecast_tariff_8": ZonneplanSensorEntityDescription(
+        "forcast_tariff_8": ZonneplanSensorEntityDescription(
             key="summary_data.price_per_hour.32.price",
             name="Zonneplan forecast tariff hour 8",
             icon="mdi:cash",
             value_factor=0.0000001,
             native_unit_of_measurement=f"{CURRENCY_EURO}/{ENERGY_KILO_WATT_HOUR}",
         ),
-        "forecast_tariff_group_1": ZonneplanSensorEntityDescription(
+        "forcast_tariff_group_1": ZonneplanSensorEntityDescription(
             key="summary_data.price_per_hour.25.tariff_group",
             name="Zonneplan forecast tariff group hour 1",
             icon="mdi:cash",
         ),
-        "forecast_tariff_group_2": ZonneplanSensorEntityDescription(
+        "forcast_tariff_group_2": ZonneplanSensorEntityDescription(
             key="summary_data.price_per_hour.26.tariff_group",
             name="Zonneplan forecast tariff group hour 2",
         ),
-        "forecast_tariff_group_3": ZonneplanSensorEntityDescription(
+        "forcast_tariff_group_3": ZonneplanSensorEntityDescription(
             key="summary_data.price_per_hour.27.tariff_group",
             name="Zonneplan forecast tariff group hour 3",
         ),
-        "forecast_tariff_group_4": ZonneplanSensorEntityDescription(
+        "forcast_tariff_group_4": ZonneplanSensorEntityDescription(
             key="summary_data.price_per_hour.28.tariff_group",
             name="Zonneplan forecast tariff group hour 4",
         ),
-        "forecast_tariff_group_5": ZonneplanSensorEntityDescription(
+        "forcast_tariff_group_5": ZonneplanSensorEntityDescription(
             key="summary_data.price_per_hour.29.tariff_group",
             name="Zonneplan forecast tariff group hour 5",
         ),
-        "forecast_tariff_group_6": ZonneplanSensorEntityDescription(
+        "forcast_tariff_group_6": ZonneplanSensorEntityDescription(
             key="summary_data.price_per_hour.30.tariff_group",
             name="Zonneplan forecast tariff group hour 6",
         ),
-        "forecast_tariff_group_7": ZonneplanSensorEntityDescription(
+        "forcast_tariff_group_7": ZonneplanSensorEntityDescription(
             key="summary_data.price_per_hour.31.tariff_group",
             name="Zonneplan forecast tariff group hour 7",
         ),
-        "forecast_tariff_group_8": ZonneplanSensorEntityDescription(
+        "forcast_tariff_group_8": ZonneplanSensorEntityDescription(
             key="summary_data.price_per_hour.32.tariff_group",
             name="Zonneplan forecast tariff group hour 8",
         ),

--- a/custom_components/zonneplan_one/const.py
+++ b/custom_components/zonneplan_one/const.py
@@ -82,7 +82,7 @@ SENSOR_TYPES: dict[str, list[ZonneplanSensorEntityDescription]] = {
             attributes=[
                 Attribute(
                     key="summary_data.price_per_hour",
-                    label="forcast",
+                    label="forecast",
                 )
             ],
         ),
@@ -107,94 +107,94 @@ SENSOR_TYPES: dict[str, list[ZonneplanSensorEntityDescription]] = {
             icon="mdi:message-text-outline",
             entity_registry_enabled_default=True,
         ),
-        "forcast_tariff_1": ZonneplanSensorEntityDescription(
+        "forecast_tariff_1": ZonneplanSensorEntityDescription(
             key="summary_data.price_per_hour.25.price",
-            name="Zonneplan forcast tariff hour 1",
+            name="Zonneplan forecast tariff hour 1",
             icon="mdi:cash",
             value_factor=0.0000001,
             native_unit_of_measurement=f"{CURRENCY_EURO}/{ENERGY_KILO_WATT_HOUR}",
         ),
-        "forcast_tariff_2": ZonneplanSensorEntityDescription(
+        "forecast_tariff_2": ZonneplanSensorEntityDescription(
             key="summary_data.price_per_hour.26.price",
-            name="Zonneplan forcast tariff hour 2",
+            name="Zonneplan forecast tariff hour 2",
             icon="mdi:cash",
             value_factor=0.0000001,
             native_unit_of_measurement=f"{CURRENCY_EURO}/{ENERGY_KILO_WATT_HOUR}",
         ),
-        "forcast_tariff_3": ZonneplanSensorEntityDescription(
+        "forecast_tariff_3": ZonneplanSensorEntityDescription(
             key="summary_data.price_per_hour.27.price",
-            name="Zonneplan forcast tariff hour 3",
+            name="Zonneplan forecast tariff hour 3",
             icon="mdi:cash",
             value_factor=0.0000001,
             native_unit_of_measurement=f"{CURRENCY_EURO}/{ENERGY_KILO_WATT_HOUR}",
         ),
-        "forcast_tariff_4": ZonneplanSensorEntityDescription(
+        "forecast_tariff_4": ZonneplanSensorEntityDescription(
             key="summary_data.price_per_hour.28.price",
-            name="Zonneplan forcast tariff hour 4",
+            name="Zonneplan forecast tariff hour 4",
             icon="mdi:cash",
             value_factor=0.0000001,
             native_unit_of_measurement=f"{CURRENCY_EURO}/{ENERGY_KILO_WATT_HOUR}",
         ),
-        "forcast_tariff_5": ZonneplanSensorEntityDescription(
+        "forecast_tariff_5": ZonneplanSensorEntityDescription(
             key="summary_data.price_per_hour.29.price",
-            name="Zonneplan forcast tariff hour 5",
+            name="Zonneplan forecast tariff hour 5",
             icon="mdi:cash",
             value_factor=0.0000001,
             native_unit_of_measurement=f"{CURRENCY_EURO}/{ENERGY_KILO_WATT_HOUR}",
         ),
-        "forcast_tariff_6": ZonneplanSensorEntityDescription(
+        "forecast_tariff_6": ZonneplanSensorEntityDescription(
             key="summary_data.price_per_hour.30.price",
-            name="Zonneplan forcast tariff hour 6",
+            name="Zonneplan forecast tariff hour 6",
             icon="mdi:cash",
             value_factor=0.0000001,
             native_unit_of_measurement=f"{CURRENCY_EURO}/{ENERGY_KILO_WATT_HOUR}",
         ),
-        "forcast_tariff_7": ZonneplanSensorEntityDescription(
+        "forecast_tariff_7": ZonneplanSensorEntityDescription(
             key="summary_data.price_per_hour.31.price",
-            name="Zonneplan forcast tariff hour 7",
+            name="Zonneplan forecast tariff hour 7",
             icon="mdi:cash",
             value_factor=0.0000001,
             native_unit_of_measurement=f"{CURRENCY_EURO}/{ENERGY_KILO_WATT_HOUR}",
         ),
-        "forcast_tariff_8": ZonneplanSensorEntityDescription(
+        "forecast_tariff_8": ZonneplanSensorEntityDescription(
             key="summary_data.price_per_hour.32.price",
-            name="Zonneplan forcast tariff hour 8",
+            name="Zonneplan forecast tariff hour 8",
             icon="mdi:cash",
             value_factor=0.0000001,
             native_unit_of_measurement=f"{CURRENCY_EURO}/{ENERGY_KILO_WATT_HOUR}",
         ),
-        "forcast_tariff_group_1": ZonneplanSensorEntityDescription(
+        "forecast_tariff_group_1": ZonneplanSensorEntityDescription(
             key="summary_data.price_per_hour.25.tariff_group",
-            name="Zonneplan forcast tariff group hour 1",
+            name="Zonneplan forecast tariff group hour 1",
             icon="mdi:cash",
         ),
-        "forcast_tariff_group_2": ZonneplanSensorEntityDescription(
+        "forecast_tariff_group_2": ZonneplanSensorEntityDescription(
             key="summary_data.price_per_hour.26.tariff_group",
-            name="Zonneplan forcast tariff group hour 2",
+            name="Zonneplan forecast tariff group hour 2",
         ),
-        "forcast_tariff_group_3": ZonneplanSensorEntityDescription(
+        "forecast_tariff_group_3": ZonneplanSensorEntityDescription(
             key="summary_data.price_per_hour.27.tariff_group",
-            name="Zonneplan forcast tariff group hour 3",
+            name="Zonneplan forecast tariff group hour 3",
         ),
-        "forcast_tariff_group_4": ZonneplanSensorEntityDescription(
+        "forecast_tariff_group_4": ZonneplanSensorEntityDescription(
             key="summary_data.price_per_hour.28.tariff_group",
-            name="Zonneplan forcast tariff group hour 4",
+            name="Zonneplan forecast tariff group hour 4",
         ),
-        "forcast_tariff_group_5": ZonneplanSensorEntityDescription(
+        "forecast_tariff_group_5": ZonneplanSensorEntityDescription(
             key="summary_data.price_per_hour.29.tariff_group",
-            name="Zonneplan forcast tariff group hour 5",
+            name="Zonneplan forecast tariff group hour 5",
         ),
-        "forcast_tariff_group_6": ZonneplanSensorEntityDescription(
+        "forecast_tariff_group_6": ZonneplanSensorEntityDescription(
             key="summary_data.price_per_hour.30.tariff_group",
-            name="Zonneplan forcast tariff group hour 6",
+            name="Zonneplan forecast tariff group hour 6",
         ),
-        "forcast_tariff_group_7": ZonneplanSensorEntityDescription(
+        "forecast_tariff_group_7": ZonneplanSensorEntityDescription(
             key="summary_data.price_per_hour.31.tariff_group",
-            name="Zonneplan forcast tariff group hour 7",
+            name="Zonneplan forecast tariff group hour 7",
         ),
-        "forcast_tariff_group_8": ZonneplanSensorEntityDescription(
+        "forecast_tariff_group_8": ZonneplanSensorEntityDescription(
             key="summary_data.price_per_hour.32.tariff_group",
-            name="Zonneplan forcast tariff group hour 8",
+            name="Zonneplan forecast tariff group hour 8",
         ),
     },
     PV_INSTALL: {


### PR DESCRIPTION
Fixed a few spelling errors, most notably `forcast` -> `forecast` in the sensors, as "forcast" isn't an existing word.

Should not be a breaking change for existing users. 

Fixes #44 