### PR TITLE
Set update_interval to 5min

### DIFF
--- a/custom_components/zonneplan_one/coordinator.py
+++ b/custom_components/zonneplan_one/coordinator.py
@@ -28,7 +28,7 @@ class ZonneplanUpdateCoordinator(DataUpdateCoordinator):
             hass,
             _LOGGER,
             name=DOMAIN,
-            update_interval=timedelta(seconds=120),
+            update_interval=timedelta(seconds=300),
         )
         self.data: dict = {}
         self.api: AsyncConfigEntryAuth = api


### PR DESCRIPTION
Quick fix as requested by Zonneplan in https://github.com/fsaris/home-assistant-zonneplan-one/issues/49#issuecomment-1420627637.

Probably we should have a look at what sensor updates how often separately, but this should at least alleviate the pressure on the API for now (buying some time)