### PR TITLE
Enable electricity and gas tariff sensors by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Unofficial integration for Zonneplan ONE solar inverter + Zonneplan connect
 - Additional sensors:
    - Current Zonneplan Electricity tariff: `€/kWh`
      - The full Electricity forecast is available as a forecast attribute of this sensor
-   - Current Zonneplan Gas tariff: `€/m³` _(default disabled)_
+   - Current Zonneplan Gas tariff: `€/m³`
    - 8 hours forecast of Zonneplan Electricity tariff: `€/kWh` _(default disabled)_
    - Current elektricity usage
    - Sustainability score
@@ -73,7 +73,7 @@ Do you have [HACS](https://hacs.xyz/) installed?
 `Zonneplan P1 electricity returned today` is what you returned to the grid
 
 ### Installing main/beta version using HACS
-1. Go to `HACS` => `Integratrions`
+1. Go to `HACS` => `Integrations`
 1. Click on the three dots icon in right bottom of the **Zonneplan ONE** card
 1. Click `Reinstall`
 1. Make sure `Show beta versions` is checked

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Unofficial integration for Zonneplan ONE solar inverter + Zonneplan connect
    - Gas first measured: `date` _(default disabled)_
    - Gas last measured: `date`
 - Additional sensors:
-   - Current Zonneplan Electricity tariff: `€/kWh` _(default disabled)_
+   - Current Zonneplan Electricity tariff: `€/kWh`
      - The full Electricity forecast is available as a forecast attribute of this sensor
    - Current Zonneplan Gas tariff: `€/m³` _(default disabled)_
    - 8 hours forecast of Zonneplan Electricity tariff: `€/kWh` _(default disabled)_

--- a/custom_components/zonneplan_one/const.py
+++ b/custom_components/zonneplan_one/const.py
@@ -79,6 +79,7 @@ SENSOR_TYPES: dict[str, list[ZonneplanSensorEntityDescription]] = {
             value_factor=0.0000001,
             native_unit_of_measurement=f"{CURRENCY_EURO}/{ENERGY_KILO_WATT_HOUR}",
             state_class=SensorStateClass.MEASUREMENT,
+            entity_registry_enabled_default=True,
             attributes=[
                 Attribute(
                     key="summary_data.price_per_hour",

--- a/custom_components/zonneplan_one/const.py
+++ b/custom_components/zonneplan_one/const.py
@@ -94,6 +94,7 @@ SENSOR_TYPES: dict[str, list[ZonneplanSensorEntityDescription]] = {
             value_factor=0.0000001,
             native_unit_of_measurement=f"{CURRENCY_EURO}/{VOLUME_CUBIC_METERS}",
             state_class=SensorStateClass.MEASUREMENT,
+            entity_registry_enabled_default=True,
             none_value_behaviour=NONE_USE_PREVIOUS,
             daily_update_hour=6,
         ),

--- a/custom_components/zonneplan_one/manifest.json
+++ b/custom_components/zonneplan_one/manifest.json
@@ -1,19 +1,19 @@
 {
   "domain": "zonneplan_one",
   "name": "Zonneplan ONE",
-  "version": "0.0.16",
-  "config_flow": true,
-  "documentation": "https://github.com/fsaris/home-assistant-zonneplan-one",
-  "issue_tracker": "https://github.com/fsaris/home-assistant-zonneplan-one/issues",
-  "requirements": [],
-  "ssdp": [],
-  "zeroconf": [],
-  "homekit": {},
   "after_dependencies": [
     "http"
   ],
   "codeowners": [
     "@fsaris"
   ],
-  "iot_class": "cloud_polling"
+  "config_flow": true,
+  "documentation": "https://github.com/fsaris/home-assistant-zonneplan-one",
+  "homekit": {},
+  "iot_class": "cloud_polling",
+  "issue_tracker": "https://github.com/fsaris/home-assistant-zonneplan-one/issues",
+  "requirements": [],
+  "ssdp": [],
+  "version": "0.0.16",
+  "zeroconf": []
 }


### PR DESCRIPTION
I've had to tell many people in different forums/Discord channels that this sensor has to be enabled manually. It probably makes sense to have this enabled by default, as many new users are installing this component to get the hourly prices in HA.

Q: do you think the gas tariff should be enabled by default as well?

`manifest.json` was sorted in a separate commit to satisfy the hassfest script, no content changes there.