### PR TITLE
API change

### DIFF
--- a/custom_components/zonneplan_one/binary_sensor.py
+++ b/custom_components/zonneplan_one/binary_sensor.py
@@ -137,7 +137,7 @@ class ZonneplanChargePointBinarySensor(ZonneplanBinarySensor):
         else:
             return self.coordinator.getConnectionValue(
                 self._connection_uuid,
-                "charge_point.{install_index}.uuid".format(
+                "charge_point_installation.{install_index}.uuid".format(
                     install_index=self._install_index
                 ),
             )
@@ -150,7 +150,7 @@ class ZonneplanChargePointBinarySensor(ZonneplanBinarySensor):
             "manufacturer": "Zonneplan",
             "name": self.coordinator.getConnectionValue(
                 self._connection_uuid,
-                "charge_point.0.label",
+                "charge_point_installation.0.label",
             ),
         }
 
@@ -158,13 +158,13 @@ class ZonneplanChargePointBinarySensor(ZonneplanBinarySensor):
             device_info["identifiers"].add((DOMAIN, self.install_uuid))
             device_info["name"] = self.coordinator.getConnectionValue(
                 self._connection_uuid,
-                "charge_point.{install_index}.label".format(
+                "charge_point_installation.{install_index}.label".format(
                     install_index=self._install_index
                 ),
             )
             device_info["model"] = self.coordinator.getConnectionValue(
                 self._connection_uuid,
-                "charge_point.{install_index}.meta.serial_number".format(
+                "charge_point_installation.{install_index}.meta.serial_number".format(
                     install_index=self._install_index
                 ),
             )

--- a/custom_components/zonneplan_one/const.py
+++ b/custom_components/zonneplan_one/const.py
@@ -24,7 +24,7 @@ DOMAIN = "zonneplan_one"
 SUMMARY = "summary_data"
 PV_INSTALL = "pv_installation"
 P1_INSTALL = "p1_installation"
-CHARGE_POINT = "charge_point"
+CHARGE_POINT = "charge_point_installation"
 
 NONE_IS_ZERO = 'none-is-zero'
 NONE_USE_PREVIOUS = 'none-is-previous'

--- a/custom_components/zonneplan_one/coordinator.py
+++ b/custom_components/zonneplan_one/coordinator.py
@@ -112,8 +112,8 @@ class ZonneplanUpdateCoordinator(DataUpdateCoordinator):
                     result[uuid]["summary_data"]["gas_price"] = getGasPriceFromSummary(summary)
                     summary_retrieved = True
 
-            if "charge_point" in connection:
-                charge_point = await self.api.async_get(uuid, "/charge-points/" + connection["charge_point"][0]["uuid"])
+            if "charge_point_installation" in connection:
+                charge_point = await self.api.async_get(uuid, "/charge-points/" + connection["charge_point_installation"][0]["uuid"])
                 if charge_point:
                     result[uuid]["charge_point_data"] = charge_point["contracts"][0]
 

--- a/custom_components/zonneplan_one/sensor.py
+++ b/custom_components/zonneplan_one/sensor.py
@@ -367,6 +367,7 @@ class ZonneplanP1Sensor(ZonneplanSensor):
             )
 
         return device_info
+
 class ZonneplanChargePointSensor(ZonneplanSensor):
     @property
     def install_uuid(self) -> str:
@@ -376,7 +377,7 @@ class ZonneplanChargePointSensor(ZonneplanSensor):
         else:
             return self.coordinator.getConnectionValue(
                 self._connection_uuid,
-                "charge_point.{install_index}.uuid".format(
+                "charge_point_installation.{install_index}.uuid".format(
                     install_index=self._install_index
                 ),
             )
@@ -389,7 +390,7 @@ class ZonneplanChargePointSensor(ZonneplanSensor):
             "manufacturer": "Zonneplan",
             "name": self.coordinator.getConnectionValue(
                 self._connection_uuid,
-                "charge_point.0.label",
+                "charge_point_installation.0.label",
             ),
         }
 
@@ -397,13 +398,13 @@ class ZonneplanChargePointSensor(ZonneplanSensor):
             device_info["identifiers"].add((DOMAIN, self.install_uuid))
             device_info["name"] = self.coordinator.getConnectionValue(
                 self._connection_uuid,
-                "charge_point.{install_index}.label".format(
+                "charge_point_installation.{install_index}.label".format(
                     install_index=self._install_index
                 ),
             )
             device_info["model"] = self.coordinator.getConnectionValue(
                 self._connection_uuid,
-                "charge_point.{install_index}.meta.serial_number".format(
+                "charge_point_installation.{install_index}.meta.serial_number".format(
                     install_index=self._install_index
                 ),
             )


### PR DESCRIPTION
After checking the logfiles i discoverd the API has been changed. The connection "charge_point" has been renamed by Zonneplan to "charge_point_installation".
I went through the code and made the required changes. After these changes the charge point data is working again.