### PR TITLE
Fix current tariff

### DIFF
--- a/custom_components/zonneplan_one/const.py
+++ b/custom_components/zonneplan_one/const.py
@@ -82,7 +82,7 @@ SENSOR_TYPES: dict[str, list[ZonneplanSensorEntityDescription]] = {
             name="Zonneplan current tariff group",
         ),
         "current_tariff": ZonneplanSensorEntityDescription(
-            key="summary_data.price_per_hour.24.price",
+            key="summary_data.price_per_hour.24.electricity_price",
             name="Zonneplan current electricity tariff",
             icon="mdi:cash",
             value_factor=0.0000001,


### PR DESCRIPTION
Zonneplan changed the API response, rendering the current tariff to "unavailable". It's an easy fix though... From `price` to `electricity_price`.

![image](https://github.com/fsaris/home-assistant-zonneplan-one/assets/33529490/86ea2a4e-b5df-4a1a-984e-b48a463865af)
