### PR TITLE
Order is gas/electricity contracts can be different for some customers

### DIFF
--- a/custom_components/zonneplan_one/coordinator.py
+++ b/custom_components/zonneplan_one/coordinator.py
@@ -97,15 +97,8 @@ class ZonneplanUpdateCoordinator(DataUpdateCoordinator):
                     result[uuid]["gas_data"] = gas
 
             # Electricity summary also contains gas data - only need to retrieve summary once
-            if "electricity" in connection:
-                summary = await self.api.async_get(uuid, "/summary")
-                if summary:
-                    result[uuid]["summary_data"] = summary
-                    result[uuid]["summary_data"]["gas_price"] = getGasPriceFromSummary(summary)
-                    summary_retrieved = True
-
             # Prevent duplicate sensors being setup if there is also an electricity contract
-            if "gas" in connection and summary_retrieved == False:
+            if ("electricity" in connection or "gas" in connection) and summary_retrieved == False:
                 summary = await self.api.async_get(uuid, "/summary")
                 if summary:
                     result[uuid]["summary_data"] = summary


### PR DESCRIPTION
I had still the issue with duplicate devices. It looked that the order in which I receive my contracts are different. This would fix it for both scenarios.

(Also this removes some duplicate code)

Continuation on PR #45