### PR TITLE
Use live data as last values

### DIFF
--- a/custom_components/zonneplan_one/coordinator.py
+++ b/custom_components/zonneplan_one/coordinator.py
@@ -133,14 +133,15 @@ class ZonneplanUpdateCoordinator(DataUpdateCoordinator):
                     uuid, "/pv_installation/charts/live"
                 )
                 if live_data:
-                    if not accounts:
-                        old = result[uuid]["live_data"]["total"]
+                    old = 0
+                    if not accounts and connection["live_data"]["total"]:
+                        old = connection["live_data"]["total"]
                     result[uuid]["live_data"] = live_data[0]
 
-                    # These entity referenced params are not updated when only updating live data
-                    if not accounts:
-                        new = result[uuid]["live_data"]["total"]
-                        last = result[uuid]["live_data"]["measurements"][-1]
+                    # These params are not updated when only selecting data from before
+                    if not accounts and connection["live_data"]["measurements"]:
+                        new = connection["live_data"]["total"]
+                        last = connection["live_data"]["measurements"][-1]
                         result[uuid]["pv_installation"][0]["meta"]["last_measured_at"] = last["measured_at"]
                         result[uuid]["pv_installation"][0]["meta"]["last_measured_power_value"] = last["value"]
                         _LOGGER.debug(
@@ -149,7 +150,7 @@ class ZonneplanUpdateCoordinator(DataUpdateCoordinator):
                             new,
                             old
                         )
-                        result[uuid]["pv_installation"][0]["meta"]["total_power_measured"] += new - old
+                        connection["pv_installation"][0]["meta"]["total_power_measured"] += new - old
 
             if "p1_installation" in connection:
                 electricity = await self.api.async_get(uuid, "/electricity-delivered")

--- a/custom_components/zonneplan_one/coordinator.py
+++ b/custom_components/zonneplan_one/coordinator.py
@@ -145,7 +145,7 @@ class ZonneplanUpdateCoordinator(DataUpdateCoordinator):
                         result[uuid]["pv_installation"][0]["meta"]["last_measured_power_value"] = last["value"]
                         _LOGGER.debug(
                             "Update total power with: %d + (%d - %d)",
-                            result[uuid]["pv_installation"][0]["meta"]["total_power_measured"],\
+                            result[uuid]["pv_installation"][0]["meta"]["total_power_measured"],
                             new,
                             old
                         )


### PR DESCRIPTION
Currently, the PV entities are based on meta values. These values get updated only when getting data from the user accounts-endpoint. Since some versions it receives an update every hour.
However, we are also polling live data every 5 minutes with newer "last values" but not using those. With this commit I use the latest values to update the meta data, so the entities gets updated in HA. 

It works locally for me for my configuration (1 solar panel system). I do not think it will works with multiple, although I do not know how the Zonneplan gives us these data in such configurations.