### PR TITLE
Fix typing warnings

### DIFF
--- a/custom_components/zonneplan_one/binary_sensor.py
+++ b/custom_components/zonneplan_one/binary_sensor.py
@@ -6,9 +6,11 @@ from homeassistant.helpers.update_coordinator import (
     CoordinatorEntity,
 )
 import logging
-from homeassistant.core import callback
+from homeassistant.core import ( 
+    callback, 
+    HomeAssistant
+)
 from homeassistant.helpers.restore_state import RestoreEntity
-from homeassistant.helpers.typing import HomeAssistantType
 from homeassistant.components.binary_sensor import (
     BinarySensorEntity,
 )
@@ -26,7 +28,7 @@ from .const import (
 _LOGGER = logging.getLogger(__name__)
 
 
-async def async_setup_entry(hass: HomeAssistantType, config_entry, async_add_entities):
+async def async_setup_entry(hass: HomeAssistant, config_entry, async_add_entities):
     coordinator: ZonneplanUpdateCoordinator = hass.data[DOMAIN][config_entry.entry_id][
         "coordinator"
     ]

--- a/custom_components/zonneplan_one/button.py
+++ b/custom_components/zonneplan_one/button.py
@@ -6,8 +6,10 @@ from homeassistant.helpers.update_coordinator import (
     CoordinatorEntity,
 )
 import logging
-from homeassistant.core import callback
-from homeassistant.helpers.typing import HomeAssistantType
+from homeassistant.core import ( 
+    callback, 
+    HomeAssistant
+)
 from homeassistant.components.button import (
     ButtonEntity,
 )
@@ -23,7 +25,7 @@ from .const import (
 _LOGGER = logging.getLogger(__name__)
 
 
-async def async_setup_entry(hass: HomeAssistantType, config_entry, async_add_entities):
+async def async_setup_entry(hass: HomeAssistant, config_entry, async_add_entities):
     coordinator: ZonneplanUpdateCoordinator = hass.data[DOMAIN][config_entry.entry_id][
         "coordinator"
     ]

--- a/custom_components/zonneplan_one/coordinator.py
+++ b/custom_components/zonneplan_one/coordinator.py
@@ -11,10 +11,12 @@ import inspect
 import os
 from aiohttp.client_exceptions import ClientResponseError
 
-from homeassistant.core import HassJob
+from homeassistant.core import ( 
+    HassJob, 
+    HomeAssistant
+)
 from homeassistant.helpers.debounce import Debouncer
 from homeassistant.helpers.event import async_call_later
-from homeassistant.helpers.typing import HomeAssistantType
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 from homeassistant.exceptions import ConfigEntryAuthFailed
 
@@ -53,7 +55,7 @@ class ZonneplanUpdateCoordinator(DataUpdateCoordinator):
 
     def __init__(
         self,
-        hass: HomeAssistantType,
+        hass: HomeAssistant,
         api: AsyncConfigEntryAuth,
     ) -> None:
         """Initialize."""

--- a/custom_components/zonneplan_one/sensor.py
+++ b/custom_components/zonneplan_one/sensor.py
@@ -9,9 +9,11 @@ from homeassistant.helpers.update_coordinator import (
     CoordinatorEntity,
 )
 import logging
-from homeassistant.core import callback
+from homeassistant.core import ( 
+    callback, 
+    HomeAssistant
+)
 from homeassistant.helpers.restore_state import RestoreEntity
-from homeassistant.helpers.typing import HomeAssistantType
 from homeassistant.components.sensor import (
     SensorDeviceClass,
     SensorEntity,
@@ -36,7 +38,7 @@ from .const import (
 _LOGGER = logging.getLogger(__name__)
 
 
-async def async_setup_entry(hass: HomeAssistantType, config_entry, async_add_entities):
+async def async_setup_entry(hass: HomeAssistant, config_entry, async_add_entities):
     coordinator: ZonneplanUpdateCoordinator = hass.data[DOMAIN][config_entry.entry_id][
         "coordinator"
     ]


### PR DESCRIPTION
Fixes all occurences on HA 2024.5 for the following warning:

> HomeAssistantType was used from zonneplan_one, this is a deprecated alias which will be removed in HA Core 2025.5. Use homeassistant.core.HomeAssistant instead, please report it to the author of the 'zonneplan_one' custom integration

Fixes #114 