### PR TITLE
Fix blocking calls

### DIFF
--- a/custom_components/zonneplan_one/const.py
+++ b/custom_components/zonneplan_one/const.py
@@ -33,6 +33,7 @@ BATTERY = "home_battery_installation"
 NONE_IS_ZERO = "none-is-zero"
 NONE_USE_PREVIOUS = "none-is-previous"
 
+VERSION = "2024.4.2"
 
 @dataclass
 class Attribute:

--- a/custom_components/zonneplan_one/zonneplan_api/api.py
+++ b/custom_components/zonneplan_one/zonneplan_api/api.py
@@ -3,9 +3,8 @@ import asyncio
 import aiohttp
 import async_timeout
 import logging
-import json
-import inspect
-import os
+
+from ..const import VERSION
 
 APP_VERSION = "4.12.1"
 API_VERSION = "v2"
@@ -23,18 +22,8 @@ class ZonneplanApi:
             "x-app-version": APP_VERSION,
             "x-api-version": API_VERSION,
             "x-app-environment": "production",
-            "x-ha-integration": self._get_integration_version(),
+            "x-ha-integration": VERSION,
         }
-
-    def _get_integration_version(self) -> str:
-        script_directory = os.path.dirname(os.path.abspath(
-            inspect.getfile(inspect.currentframe())))
-        f = open(script_directory + '/../manifest.json')
-        manifest = json.load(f)
-
-        _LOGGER.debug("Version from manifest.json -> %s", manifest["version"])
-
-        return manifest["version"]
 
     async def async_request_temp_pass(self, email: str) -> str:
         try:


### PR DESCRIPTION
I've taken the approach of adding the `VERSION` to the constants and import that in the API calls instead of doing (expensive) file reads on `manifest.json`.

It does mean that the constant needs to be updated with the latest version number upon release, just as `manifest.json` needs to be updated.

Tested locally, works fine. Fixes #117