### PR TITLE
Changed SensorStateClass.MEASUREMENT to SensorStateClass.TOTAL

### DIFF
--- a/custom_components/zonneplan_one/const.py
+++ b/custom_components/zonneplan_one/const.py
@@ -480,7 +480,7 @@ SENSOR_TYPES: dict[str, list[ZonneplanSensorEntityDescription]] = {
             name="Result this year",
             device_class=SensorDeviceClass.MONETARY,
             native_unit_of_measurement='EUR',
-            state_class=SensorStateClass.MEASUREMENT,
+            state_class=SensorStateClass.TOTAL,
             entity_registry_enabled_default=True,
             attributes=[
                 Attribute(
@@ -506,7 +506,7 @@ SENSOR_TYPES: dict[str, list[ZonneplanSensorEntityDescription]] = {
             name="Result last year",
             device_class=SensorDeviceClass.MONETARY,
             native_unit_of_measurement='EUR',
-            state_class=SensorStateClass.MEASUREMENT,
+            state_class=SensorStateClass.TOTAL,
             entity_registry_enabled_default=True,
             attributes=[
                 Attribute(
@@ -552,7 +552,7 @@ SENSOR_TYPES: dict[str, list[ZonneplanSensorEntityDescription]] = {
             name="Result this month",
             device_class=SensorDeviceClass.MONETARY,
             native_unit_of_measurement='EUR',
-            state_class=SensorStateClass.MEASUREMENT,
+            state_class=SensorStateClass.TOTAL,
             entity_registry_enabled_default=True,
             attributes=[
                 Attribute(
@@ -578,7 +578,7 @@ SENSOR_TYPES: dict[str, list[ZonneplanSensorEntityDescription]] = {
             name="Result last month",
             device_class=SensorDeviceClass.MONETARY,
             native_unit_of_measurement='EUR',
-            state_class=SensorStateClass.MEASUREMENT,
+            state_class=SensorStateClass.TOTAL,
             entity_registry_enabled_default=True,
             attributes=[
                 Attribute(


### PR DESCRIPTION
Changed SensorStateClass.MEASUREMENT to SensorStateClass.TOTAL for sensors batterij_result_this/last_month and batterij_result_this/last_year. SensorStateClass.MEASUREMENT cannot be combined with SensorDeviceClass.MONETARY according to Home Assistant. Not sure if I agree with that, as I can measure the amount in my bank account.....