### PR TITLE
feat: add enable_gas config option and improve gas meter detection

### DIFF
--- a/custom_components/zonneplan_one/__init__.py
+++ b/custom_components/zonneplan_one/__init__.py
@@ -11,6 +11,7 @@ from homeassistant.helpers import (
 )
 
 from . import api, config_flow
+from .config_flow import CONF_ENABLE_GAS
 from .const import (
     BATTERY,
     BATTERY_CHARTS,
@@ -79,6 +80,10 @@ async def async_setup(
 
 async def async_setup_entry(hass: HomeAssistant, entry: ZonneplanConfigEntry) -> bool:  # noqa: PLR0912
     """Set up Zonneplan from a config entry."""
+    # Get enable_gas option, default to True
+    # Guard against None options dict (can occur on first setup before options are saved)
+    enable_gas = (entry.options or {}).get(CONF_ENABLE_GAS, True)
+
     implementation = await config_entry_oauth2_flow.async_get_config_entry_implementation(hass, entry)
 
     session = config_entry_oauth2_flow.OAuth2Session(hass, entry, implementation)
@@ -113,7 +118,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: ZonneplanConfigEntry) ->
                     ),
                 )
 
-            if GAS in contracts:
+            # Only instantiate GAS coordinator if gas meter is registered AND gas is enabled
+            gas_meter_registered_in_connection = False
+            if enable_gas and GAS in contracts:
+                for contract in contracts[GAS]:
+                    if contract.get("meta", {}).get("gas_last_measured_at"):
+                        gas_meter_registered_in_connection = True
+                        break
+
+            if gas_meter_registered_in_connection:
                 account_coordinator.add_coordinator(
                     connection["uuid"],
                     GAS,
@@ -125,6 +138,17 @@ async def async_setup_entry(hass: HomeAssistant, entry: ZonneplanConfigEntry) ->
                         contracts[GAS][0],
                     ),
                 )
+            elif GAS in contracts:
+                if not enable_gas:
+                    _LOGGER.debug(
+                        "Skipping GAS coordinator for connection %s: gas disabled in options",
+                        connection["uuid"],
+                    )
+                else:
+                    _LOGGER.debug(
+                        "Skipping GAS coordinator for connection %s: no gas meter registered",
+                        connection["uuid"],
+                    )
 
             if PV_INSTALL in contracts:
                 account_coordinator.add_coordinator(
@@ -153,10 +177,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ZonneplanConfigEntry) ->
                 )
 
                 gas_meter_registered = False
-                for contract in contracts[P1_INSTALL]:
-                    if contract.get("meta", {}).get("gas_last_measured_at"):
-                        gas_meter_registered = True
-                        break
+                if enable_gas:
+                    for contract in contracts[P1_INSTALL]:
+                        if contract.get("meta", {}).get("gas_last_measured_at"):
+                            gas_meter_registered = True
+                            break
 
                 if gas_meter_registered:
                     account_coordinator.add_coordinator(
@@ -168,6 +193,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ZonneplanConfigEntry) ->
                             address_group["uuid"],
                             connection["uuid"],
                             contracts[P1_INSTALL],
+                            enable_gas=enable_gas,
                         ),
                     )
 

--- a/custom_components/zonneplan_one/api.py
+++ b/custom_components/zonneplan_one/api.py
@@ -71,13 +71,13 @@ class AsyncConfigEntryAuth(ZonneplanApi):
         chart_date_str = chart_date.isoformat()
         return await self._async_get(f"contracts/{contract_uuid}/home_battery_installation/charts/{chart}?date={chart_date_str}")
 
-    async def async_get_battery_control_mode(self, contract_uuid: str) -> dict | None:
+    async def async_get_battery_control_mode(self, contract_uuid: str, *, ignore_etag: bool = False) -> dict | None:
         """Get battery control mode."""
-        return await self._async_get(f"api/contracts/{contract_uuid}/home-battery/control-mode")
+        return await self._async_get(f"api/contracts/{contract_uuid}/home-battery/control-mode", ignore_etag=ignore_etag)
 
-    async def async_get_battery_home_optimization(self, contract_uuid: str) -> dict | None:
-        """Get battery control mode."""
-        return await self._async_get(f"api/contracts/{contract_uuid}/home-battery/control-mode/home_optimization")
+    async def async_get_battery_home_optimization(self, contract_uuid: str, *, ignore_etag: bool = False) -> dict | None:
+        """Get battery home optimization."""
+        return await self._async_get(f"api/contracts/{contract_uuid}/home-battery/control-mode/home_optimization", ignore_etag=ignore_etag)
 
     async def async_set_reserve_discharge(self, connection_uuid: str, contract_uuid: str, value: int) -> dict:
         """Set battery reserve discharge."""

--- a/custom_components/zonneplan_one/config_flow.py
+++ b/custom_components/zonneplan_one/config_flow.py
@@ -14,12 +14,19 @@ from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
+CONF_ENABLE_GAS = "enable_gas"
+
 
 class ZonneplanLoginFlowHandler(config_entry_oauth2_flow.AbstractOAuth2FlowHandler, domain=DOMAIN):
     """Config flow to handle Zonneplan authentication."""
 
     DOMAIN = DOMAIN
     CONNECTION_CLASS = config_entries.CONN_CLASS_CLOUD_POLL
+
+    @staticmethod
+    def async_get_options_flow(config_entry: config_entries.ConfigEntry) -> config_entries.OptionsFlow:
+        """Return the options flow."""
+        return ZonneplanOptionsFlowHandler(config_entry)
 
     def __init__(self) -> None:
         self._email = ""
@@ -126,3 +133,29 @@ class ZonneplanLoginFlowHandler(config_entry_oauth2_flow.AbstractOAuth2FlowHandl
 
         self.logger.info("Create entry: %s", data["email"])
         return self.async_create_entry(title=data["email"], data=data)
+
+
+class ZonneplanOptionsFlowHandler(config_entries.OptionsFlow):
+    """Options flow for Zonneplan integration."""
+
+    def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
+        """Initialize options flow."""
+        self.config_entry = config_entry
+
+    async def async_step_init(self, user_input: dict[str, Any] | None = None) -> config_entries.ConfigFlowResult:
+        """Manage options."""
+        if user_input is not None:
+            return self.async_create_entry(title="", data=user_input)
+
+        # Default enable_gas to True if not set
+        current_options = dict(self.config_entry.options or {})
+        enable_gas = current_options.get(CONF_ENABLE_GAS, True)
+
+        return self.async_show_form(
+            step_id="init",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(CONF_ENABLE_GAS, default=enable_gas): bool,
+                }
+            ),
+        )

--- a/custom_components/zonneplan_one/const.py
+++ b/custom_components/zonneplan_one/const.py
@@ -48,7 +48,7 @@ BATTERY_CHARTS = "battery_charts"
 NONE_IS_ZERO = "none-is-zero"
 NONE_USE_PREVIOUS = "none-is-previous"
 
-VERSION = "2026.5.1"
+VERSION = "2026.5.2"
 
 
 @dataclass

--- a/custom_components/zonneplan_one/coordinators/battery_control_data_coordinator.py
+++ b/custom_components/zonneplan_one/coordinators/battery_control_data_coordinator.py
@@ -51,11 +51,22 @@ class BatteryControlDataUpdateCoordinator(ZonneplanDataUpdateCoordinator):
         try:
             data = self.data or {}
 
-            battery_control_mode = await self.api.async_get_battery_control_mode(self.contract["uuid"])
+            # On first fetch (no cached data), ignore etag to ensure we get a full 200 response
+            # instead of a 304, which would return None and leave the data empty.
+            # Subsequent fetches use etags normally for efficiency.
+            has_cached_battery_control = "battery_control_mode" in data
+            battery_control_mode = await self.api.async_get_battery_control_mode(
+                self.contract["uuid"],
+                ignore_etag=not has_cached_battery_control
+            )
             if battery_control_mode:
                 data["battery_control_mode"] = battery_control_mode
 
-            battery_home_optimization = await self.api.async_get_battery_home_optimization(self.contract["uuid"])
+            has_cached_battery_optimization = "battery_home_optimization" in data
+            battery_home_optimization = await self.api.async_get_battery_home_optimization(
+                self.contract["uuid"],
+                ignore_etag=not has_cached_battery_optimization
+            )
             if battery_home_optimization:
                 data["battery_home_optimization"] = battery_home_optimization
 

--- a/custom_components/zonneplan_one/coordinators/gas_data_coordinator.py
+++ b/custom_components/zonneplan_one/coordinators/gas_data_coordinator.py
@@ -24,7 +24,7 @@ class GasDataUpdateCoordinator(ZonneplanDataUpdateCoordinator):
     address_uuid: str
     connection_uuid: str
     contracts: list[ZonneplanContract]
-    _statistics_service: GasStatisticsService
+    _statistics_service: GasStatisticsService | None
 
     def __init__(
         self,
@@ -33,6 +33,7 @@ class GasDataUpdateCoordinator(ZonneplanDataUpdateCoordinator):
         address_uuid: str,
         connection_uuid: str,
         contracts: list[ZonneplanContract],
+        enable_gas: bool = True,
     ) -> None:
         """Initialize."""
         super().__init__(
@@ -48,12 +49,15 @@ class GasDataUpdateCoordinator(ZonneplanDataUpdateCoordinator):
         self.connection_uuid = connection_uuid
         self.contracts = contracts
 
-        self._statistics_service = GasStatisticsService(
-            hass=hass,
-            api=self.api,
-            connection_uuid=self.connection_uuid,
-            gas_id=self.statistics_id,
-        )
+        if enable_gas:
+            self._statistics_service = GasStatisticsService(
+                hass=hass,
+                api=self.api,
+                connection_uuid=self.connection_uuid,
+                gas_id=self.statistics_id,
+            )
+        else:
+            self._statistics_service = None
 
     async def _async_update_data(self) -> dict:
         """Fetch the latest status."""
@@ -66,7 +70,7 @@ class GasDataUpdateCoordinator(ZonneplanDataUpdateCoordinator):
             raise
         else:
             _LOGGER.debug("Update gas data: %s", gas)
-            if gas:
+            if gas and self._statistics_service:
                 await self._statistics_service.process_payload(gas)
 
             return gas or self.data
@@ -77,4 +81,5 @@ class GasDataUpdateCoordinator(ZonneplanDataUpdateCoordinator):
 
     async def async_backfill_statistics(self, start_date: datetime) -> None:
         """Backfill statistics from start_date until now."""
-        await self._statistics_service.async_backfill_from(start_date)
+        if self._statistics_service:
+            await self._statistics_service.async_backfill_from(start_date)

--- a/custom_components/zonneplan_one/coordinators/statistics.py
+++ b/custom_components/zonneplan_one/coordinators/statistics.py
@@ -290,10 +290,10 @@ class BaseZonneplanStatisticsService(ABC):
                 continue
 
             if not day_payload:
-                msg = "Missing day payload"
-                if notification_id:
-                    persistent_notification.create(self.hass, msg, "Statistics backfill failed", notification_id)
-                raise ZonneplanApiError(msg)
+                # For connections with no data (e.g., no gas meter), skip this day instead of failing
+                _LOGGER.debug("Empty day payload for %s, advancing to next day", current_day)
+                current_day += timedelta(days=1)
+                continue
 
             consecutive_failures = 0
             measurements = self._extract_measurements(day_payload, "backfill")

--- a/custom_components/zonneplan_one/manifest.json
+++ b/custom_components/zonneplan_one/manifest.json
@@ -15,6 +15,6 @@
   "issue_tracker": "https://github.com/fsaris/home-assistant-zonneplan-one/issues",
   "requirements": [],
   "ssdp": [],
-  "version": "2026.5.1",
+  "version": "2026.5.2",
   "zeroconf": []
 }


### PR DESCRIPTION
- Allow users to enable/disable gas coordinator via config option
- Check if gas meter is actually registered before instantiating coordinator
- Add debug logging for skipped coordinators
- Guard against None options dict on initial setup