### PR TITLE
Improve diagnostics redaction and request safety

### DIFF
--- a/custom_components/zonneplan_one/api.py
+++ b/custom_components/zonneplan_one/api.py
@@ -94,7 +94,7 @@ class AsyncConfigEntryAuth(ZonneplanApi):
     async def _async_get(self, path: str, *, ignore_etag: bool = False) -> dict | None:
         _LOGGER.info("fetch: %s", path)
 
-        headers = self._request_headers
+        headers = dict(self._request_headers)
         url = "https://app-api.zonneplan.nl/" + path
 
         if not ignore_etag and self._etags.get(url):
@@ -156,7 +156,7 @@ class AsyncConfigEntryAuth(ZonneplanApi):
             "POST",
             "https://app-api.zonneplan.nl/connections/" + connection_uuid + path,
             json=params,
-            headers=self._request_headers,
+            headers=dict(self._request_headers),
         )
 
         _LOGGER.debug("ZonneplanAPI response header: %s", response.headers)

--- a/custom_components/zonneplan_one/diagnostics.py
+++ b/custom_components/zonneplan_one/diagnostics.py
@@ -10,7 +10,22 @@ if TYPE_CHECKING:
 
     from .coordinators.account_data_coordinator import ZonneplanConfigEntry
 
-TO_REDACT = ["address", "organization", "chat", "user_account"]
+TO_REDACT = [
+    "address",
+    "chat",
+    "coordinate",
+    "coordinates",
+    "identifier",
+    "lat",
+    "latitude",
+    "lng",
+    "lon",
+    "longitude",
+    "organization",
+    "serial_number",
+    "sgn_serial_number",
+    "user_account",
+]
 
 
 async def async_get_config_entry_diagnostics(
@@ -32,5 +47,5 @@ async def async_get_config_entry_diagnostics(
     return {
         "account_data": async_redact_data(entry.runtime_data.data, TO_REDACT),
         "last_api_responses": async_redact_data(entry.runtime_data.api.diagnostics, TO_REDACT),
-        "coordinator_data": coordinator_data,
+        "coordinator_data": async_redact_data(coordinator_data, TO_REDACT),
     }

--- a/custom_components/zonneplan_one/zonneplan_api/api.py
+++ b/custom_components/zonneplan_one/zonneplan_api/api.py
@@ -31,7 +31,7 @@ class ZonneplanApi:
                 session.post(
                     LOGIN_REQUEST_URI,
                     json={"email": email},
-                    headers=self._request_headers,
+                    headers=dict(self._request_headers),
                 ) as response,
             ):
                 response.raise_for_status()
@@ -73,7 +73,7 @@ class ZonneplanApi:
             timeout = aiohttp.ClientTimeout(total=10)
             async with (
                 aiohttp.ClientSession(timeout=timeout) as session,
-                session.get(LOGIN_REQUEST_URI + "/" + uuid, headers=self._request_headers) as response,
+                session.get(LOGIN_REQUEST_URI + "/" + uuid, headers=dict(self._request_headers)) as response,
             ):
                 response.raise_for_status()
                 _LOGGER.debug(
@@ -83,7 +83,7 @@ class ZonneplanApi:
                 )
 
                 response_json = await response.json()
-                _LOGGER.debug("Temporary password response body json: %s", response_json)
+                _LOGGER.debug("Temporary password response received")
 
         except TimeoutError:
             _LOGGER.exception("Timeout calling ZonneplanAPI to request temporary password")
@@ -129,14 +129,14 @@ class ZonneplanApi:
         return await self._async_request_new_token(grant_params)
 
     async def _async_request_new_token(self, grant_params: dict[str, str]) -> dict:
-        _LOGGER.info("_async_request_new_token: %s", grant_params)
+        _LOGGER.debug("Requesting new OAuth token using grant type %s", grant_params.get("grant_type"))
 
         timeout = aiohttp.ClientTimeout(total=30)
         async with (
             aiohttp.ClientSession(timeout=timeout) as session,
             session.post(
                 OAUTH2_TOKEN_URI,
-                headers=self._request_headers,
+                headers=dict(self._request_headers),
                 json=grant_params,
                 allow_redirects=True,
             ) as response,
@@ -147,6 +147,6 @@ class ZonneplanApi:
             response.raise_for_status()
             _LOGGER.info("ZonneplanAPI oAuth Token get json from response")
             response_json = await response.json()
-            _LOGGER.debug("ZonneplanAPI oAuth Token response body: %s", response_json)
+            _LOGGER.debug("ZonneplanAPI oAuth Token response body received")
 
         return response_json


### PR DESCRIPTION
## Summary

This PR makes a small set of privacy and request-safety improvements:

- redact coordinator-backed diagnostics data with the existing diagnostics redaction helper
- add redaction keys for common private location/device identifiers
- avoid mutating shared request headers when adding endpoint-specific `If-None-Match` headers
- pass copied request headers for POST/login/token requests as a defensive safety improvement
- stop logging temporary-password/token response bodies and OAuth grant secrets
- declare explicit `PARALLEL_UPDATES` values for coordinator-backed and action platforms

## Why

Diagnostics can include account, contract, device, location, or installation metadata from coordinators. Redacting `coordinator_data` makes diagnostics safer to share while keeping normal measurements available.

The API client also reused a shared headers dictionary. Since `If-None-Match` is endpoint-specific, copying headers before adding the ETag avoids accidentally leaking one endpoint's ETag into later unrelated requests.

OAuth login/token flows should not log one-time passwords, refresh tokens, or token response bodies.

Finally, explicit `PARALLEL_UPDATES` follows Home Assistant's integration quality guidance:
- `0` for coordinator-backed read-only platforms
- `1` for action/control platforms

## Verification

- `ruff check .`
- `python3 -m compileall -q custom_components/zonneplan_one`
- targeted ad-hoc verifier for:
  - diagnostics redaction
  - request-header copying
  - removed sensitive logging
  - `PARALLEL_UPDATES` constants
- live-tested on my Home Assistant 2026.6.4 instance with this custom component patched locally:
  - backup created before patching
  - `ha core check` passed
  - Home Assistant Core restarted successfully
  - Zonneplan entities loaded after restart
  - Zonneplan values remained available and counters continued increasing
  - downloaded diagnostics showed redaction was applied
  - no Zonneplan setup errors observed in Core logs after restart

## Notes

During local live testing there were unrelated existing Electrolux/HomeConnect errors in the Home Assistant logs. No Zonneplan errors were observed.
