### PR TITLE
Implement new endpoints for electricity and gas prices

### DIFF
--- a/custom_components/zonneplan_one/api.py
+++ b/custom_components/zonneplan_one/api.py
@@ -91,6 +91,9 @@ class AsyncConfigEntryAuth(ZonneplanApi):
             params,
         )
 
+    async def async_get_consumer_prices(self, chart_name: str) -> dict | None:
+        return await self._async_get(f"api/consumer-prices/charts/{chart_name}")
+
     async def _async_get(self, path: str, *, ignore_etag: bool = False) -> dict | None:
         _LOGGER.info("fetch: %s", path)
 

--- a/custom_components/zonneplan_one/const.py
+++ b/custom_components/zonneplan_one/const.py
@@ -155,6 +155,48 @@ SENSOR_TYPES: dict[
             entity_registry_enabled_default=True,
             attributes=[
                 Attribute(
+                    key="legacy_price_per_hour",
+                    label="forecast",
+                )
+            ],
+        ),
+        "current_quarter_hourly_electricity_tariff": ZonneplanSensorEntityDescription(
+            key="quarter_hourly_electricity_price",
+            key_lambda=lambda: (
+                f"price_per_date_and_quarter_hour.{
+                    datetime.now(UTC)
+                    .replace(minute=(datetime.now(UTC).minute // 15) * 15, second=0, microsecond=0)
+                    .strftime('%Y-%m-%d %H:%M')
+                }.price_tax_included.amount"
+            ),
+            name="Current quarter hourly electricity tariff",
+            translation_key="current_quarter_hourly_electricity_tariff",
+            icon="mdi:cash",
+            value_factor=0.0000001,
+            native_unit_of_measurement=f"{CURRENCY_EURO}/{UnitOfEnergy.KILO_WATT_HOUR}",
+            suggested_display_precision=2,
+            state_class=SensorStateClass.MEASUREMENT,
+            entity_registry_enabled_default=True,
+            attributes=[
+                Attribute(
+                    key="price_per_quarter_hour",
+                    label="forecast",
+                )
+            ],
+        ),
+        "current_hourly_electricity_tariff": ZonneplanSensorEntityDescription(
+            key="hourly_electricity_price",
+            key_lambda=lambda: f"price_per_date_and_hour.{datetime.now(UTC).strftime('%Y-%m-%d %H')}.electricity_price",
+            name="Current hourly electricity tariff",
+            translation_key="hourly_electricity_tariff",
+            icon="mdi:cash",
+            value_factor=0.0000001,
+            native_unit_of_measurement=f"{CURRENCY_EURO}/{UnitOfEnergy.KILO_WATT_HOUR}",
+            suggested_display_precision=2,
+            state_class=SensorStateClass.MEASUREMENT,
+            entity_registry_enabled_default=True,
+            attributes=[
+                Attribute(
                     key="price_per_hour",
                     label="forecast",
                 )

--- a/custom_components/zonneplan_one/coordinators/summary_data_coordinator.py
+++ b/custom_components/zonneplan_one/coordinators/summary_data_coordinator.py
@@ -1,5 +1,5 @@
 import logging
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from http import HTTPStatus
 
 import homeassistant.util.dt as dt_util
@@ -17,42 +17,62 @@ from .zonneplan_data_update_coordinator import ZonneplanDataUpdateCoordinator
 _LOGGER = logging.getLogger(__name__)
 
 
-def get_price_per_hour_by_date(summary: dict) -> dict:
-    prices = {}
-    if "price_per_hour" not in summary:
-        return prices
+def get_price_per_hour_by_date(prices: list[dict]) -> dict:
+    price_by_hour = {}
+    for price_info in prices:
+        price_by_hour[price_info["datetime"].strftime("%Y-%m-%d %H")] = price_info
+    return price_by_hour
 
-    for hour in summary["price_per_hour"]:
-        date = dt_util.parse_datetime(hour["datetime"])
-        if date:
-            prices[date.strftime("%Y-%m-%d %H")] = hour
+
+def get_price_per_quarter_hour(data: dict) -> dict:
+    price_by_quarter_hour = {}
+    price_series = get_price_series_from_chart_data(data)
+    for price_data in price_series:
+        dt = dt_util.parse_datetime(price_data["start_date"])
+        quarter_dt = dt.replace(minute=(dt.minute // 15) * 15, second=0, microsecond=0).strftime("%Y-%m-%d %H:%M")
+        price_by_quarter_hour[quarter_dt] = price_data
+    return price_by_quarter_hour
+
+
+def get_energy_price(data: dict, dt: datetime | None = None) -> int | None:
+    if dt is None:
+        dt = datetime.now(UTC)
+    price = None
+    price_series = get_price_series_from_chart_data(data)
+    for price_data in price_series:
+        start_datetime = dt_util.parse_datetime(price_data["start_date"])
+        end_datetime = dt_util.parse_datetime(price_data["end_date"])
+        if start_datetime <= dt < end_datetime:
+            price = price_data["price_tax_included"]["amount"]
+            break
+    return price
+
+
+def get_price_series_from_chart_data(data: dict) -> list[dict]:
+    return data.get("chart", {}).get("series", {}).get("prices", [])
+
+
+def prepare_prices(data: dict) -> list[dict]:
+    prices = []
+    price_series = get_price_series_from_chart_data(data)
+    for price_data in price_series:
+        start_datetime = dt_util.parse_datetime(price_data["start_date"])
+        price = price_data["price_tax_included"]["amount"]
+        price_excl_tax = price_data["price_tax_excluded"]["amount"]
+
+        price_info = {
+            "datetime": start_datetime,
+            "electricity_price": price,
+            "electricity_price_excl_tax": price_excl_tax,
+        }
+        sustainability_score = price_data.get("sustainability_score", {}).get("permille", 0)
+        tariff_group = price_data.get("tariff_group", "")
+        price_info["sustainability_score"] = sustainability_score
+        price_info["tariff_group"] = tariff_group
+
+        prices.append(price_info)
 
     return prices
-
-
-def get_gas_price_from_summary(summary: dict) -> str | None:
-    if "price_per_hour" not in summary:
-        return None
-
-    for hour in summary["price_per_hour"]:
-        if "gas_price" in hour:
-            return hour["gas_price"]
-
-    return None
-
-
-def get_next_gas_price_from_summary(summary: dict) -> str | None:
-    if "price_per_hour" not in summary:
-        return None
-
-    first_price_found = False
-    for hour in summary["price_per_hour"]:
-        if "gas_price" in hour:
-            if first_price_found:
-                return hour["gas_price"]
-            first_price_found = True
-
-    return None
 
 
 class SummaryDataUpdateCoordinator(ZonneplanDataUpdateCoordinator):
@@ -85,19 +105,32 @@ class SummaryDataUpdateCoordinator(ZonneplanDataUpdateCoordinator):
         self.connection_uuid = connection_uuid
         self.contract = contract
 
-        self._unsub_hour_update = None
+        self._unsub_quarter_hour_update = None
 
     async def _async_update_data(self) -> dict:
         """Fetch the latest status."""
         try:
-            summary = await self.api.async_get(self.connection_uuid, "/summary")
-            if summary:
-                summary["gas_price"] = get_gas_price_from_summary(summary)
-                summary["gas_price_next"] = get_next_gas_price_from_summary(summary)
-                summary["price_per_date_and_hour"] = get_price_per_hour_by_date(summary)
+            summary = await self.api.async_get(self.connection_uuid, "/summary") or self.data
+            hourly = await self.api.async_get_consumer_prices("electricity-hourly") or self.data.get("hourly")
+            quarter_hourly = await self.api.async_get_consumer_prices("electricity-quarter-hourly") or self.data.get("quarter_hourly")
+            gas_daily = await self.api.async_get_consumer_prices("gas-daily") or self.data.get("gas_daily")
+            if hourly:
+                summary["hourly"] = hourly
+                legacy_hourly_electricity_prices = prepare_prices(hourly)
+                summary["legacy_price_per_hour"] = legacy_hourly_electricity_prices
+                summary["price_per_date_and_hour"] = get_price_per_hour_by_date(legacy_hourly_electricity_prices)
+                summary["price_per_hour"] = get_price_series_from_chart_data(hourly)
+            if quarter_hourly:
+                summary["quarter_hourly"] = quarter_hourly
+                summary["price_per_date_and_quarter_hour"] = get_price_per_quarter_hour(quarter_hourly)
+                summary["price_per_quarter_hour"] = get_price_series_from_chart_data(quarter_hourly)
+            if gas_daily:
+                summary["gas_daily"] = gas_daily
+                summary["gas_price"] = get_energy_price(gas_daily)
+                summary["gas_price_next"] = get_energy_price(gas_daily, datetime.now(UTC) + timedelta(days=1))
 
-                if not self._unsub_hour_update:
-                    self._schedule_hourly_listener_update()
+            if not self._unsub_quarter_hour_update:
+                self._schedule_quarter_hourly_listener_update()
 
         except ClientResponseError as e:
             if e.status == HTTPStatus.UNAUTHORIZED:
@@ -111,23 +144,23 @@ class SummaryDataUpdateCoordinator(ZonneplanDataUpdateCoordinator):
     async def async_shutdown(self) -> None:
         """Cancel any scheduled call, and ignore new runs."""
         await super().async_shutdown()
-        if self._unsub_hour_update:
-            self._unsub_hour_update()
-            self._unsub_hour_update = None
+        if self._unsub_quarter_hour_update:
+            self._unsub_quarter_hour_update()
+            self._unsub_quarter_hour_update = None
 
-    def _schedule_hourly_listener_update(self) -> None:
-        """Schedule hourly sensor (listeners) update."""
-        if self._unsub_hour_update:
-            self._unsub_hour_update()
+    def _schedule_quarter_hourly_listener_update(self) -> None:
+        """Schedule quarter hourly sensor (listeners) update."""
+        if self._unsub_quarter_hour_update:
+            self._unsub_quarter_hour_update()
 
         now = dt_util.utcnow()
-        next_hour = now.replace(minute=0, second=0, microsecond=0) + timedelta(hours=1)
+        next_hour = now.replace(minute=(now.minute // 15) * 15, second=0, microsecond=0) + timedelta(minutes=15)
 
         @callback
         def _handle(_: datetime) -> None:
             _LOGGER.debug("Next hour: refresh sensor data")
 
             self.async_update_listeners()
-            self._schedule_hourly_listener_update()
+            self._schedule_quarter_hourly_listener_update()
 
-        self._unsub_hour_update = async_track_point_in_utc_time(self.hass, _handle, next_hour)
+        self._unsub_quarter_hour_update = async_track_point_in_utc_time(self.hass, _handle, next_hour)


### PR DESCRIPTION
Now energy prices are using new endpoints defined in #311 by keep using `SummaryDataUpdateCoordinator`.

In another patch I would like to separate energy prices from connections/users so people without Zonneplan subscription/account would be able to use Zonneplan's energy prices.

Adding two sensor named `current_quarter_hourly_electricity_tariff` and `current_hourly_electricity_tariff` with data coming directly from zonneplan api. 
example forecast attribute data:
```yaml
    - start_date: '2026-07-04T16:00:00+00:00'
      end_date: '2026-07-04T17:00:00+00:00'
      price_tax_included:
        amount: 1937831
      price_tax_excluded:
        amount: 829350
      tariff_group: low
      sustainability_score:
        permille: 1000
    - start_date: '2026-07-04T17:00:00+00:00'
      end_date: '2026-07-04T18:00:00+00:00'
      price_tax_included:
        amount: 2548004
      price_tax_excluded:
        amount: 1439523
      tariff_group: normal
      sustainability_score:
        permille: 986
```
resolves #311