### PR TITLE
Declare explicit platform parallel updates

### DIFF
--- a/custom_components/zonneplan_one/binary_sensor.py
+++ b/custom_components/zonneplan_one/binary_sensor.py
@@ -31,6 +31,8 @@ from .entity import BatteryEntity, ChargePointEntity, PvEntity
 
 _LOGGER = logging.getLogger(__name__)
 
+PARALLEL_UPDATES = 0
+
 
 async def async_setup_entry(
     hass: HomeAssistant,  # noqa: ARG001 Unused function argument: `hass`

--- a/custom_components/zonneplan_one/button.py
+++ b/custom_components/zonneplan_one/button.py
@@ -22,6 +22,8 @@ from .entity import ChargePointEntity
 
 _LOGGER = logging.getLogger(__name__)
 
+PARALLEL_UPDATES = 1
+
 
 async def async_setup_entry(
     hass: HomeAssistant,  # noqa: ARG001 Unused function argument: `hass`

--- a/custom_components/zonneplan_one/number.py
+++ b/custom_components/zonneplan_one/number.py
@@ -20,6 +20,8 @@ from .entity import BatteryEntity
 
 _LOGGER = logging.getLogger(__name__)
 
+PARALLEL_UPDATES = 1
+
 
 async def async_setup_entry(
     hass: HomeAssistant,  # noqa: ARG001 Unused function argument: `hass`

--- a/custom_components/zonneplan_one/select.py
+++ b/custom_components/zonneplan_one/select.py
@@ -20,6 +20,8 @@ from .entity import BatteryEntity
 
 _LOGGER = logging.getLogger(__name__)
 
+PARALLEL_UPDATES = 1
+
 
 async def async_setup_entry(
     hass: HomeAssistant,  # noqa: ARG001 Unused function argument: `hass`

--- a/custom_components/zonneplan_one/sensor.py
+++ b/custom_components/zonneplan_one/sensor.py
@@ -70,6 +70,8 @@ from .entity import (
 
 _LOGGER = logging.getLogger(__name__)
 
+PARALLEL_UPDATES = 0
+
 
 async def async_setup_entry(
     hass: HomeAssistant,


### PR DESCRIPTION
## Summary

This PR moves the explicit `PARALLEL_UPDATES` declarations out of #308 into a separate, focused change.

It declares:

- `PARALLEL_UPDATES = 0` for coordinator-backed read-only platforms (`sensor`, `binary_sensor`)
- `PARALLEL_UPDATES = 1` for action/control platforms (`button`, `number`, `select`)

## Why

Home Assistant's Integration Quality Scale has a rule for explicitly specifying parallel updates. Keeping this as a separate PR makes it easier to review and test the behavior independently from the diagnostics/header/logging safety changes in #308.

## Verification

- `python3 -m compileall -q custom_components/zonneplan_one`
- `uvx --from ruff==0.15.17 ruff check .`
