### PR TITLE
Exclude electricity forecast information from recorder

### DIFF
--- a/custom_components/zonneplan_one/sensor.py
+++ b/custom_components/zonneplan_one/sensor.py
@@ -454,6 +454,7 @@ class ZonneplanSensor(CoordinatorEntity, RestoreSensor, ABC):
 
 class ZonneplanElectricitySensor(ZonneplanSensor):
     coordinator: SummaryDataUpdateCoordinator | ElectricityPricesDataUpdateCoordinator
+    _unrecorded_attributes = frozenset({"forecast"})
 
     def __init__(
         self,


### PR DESCRIPTION
Keeping forecast information in recorder db is unnecessary as it's tied directly to EPEX prices

If needed, in the future there can be another attribute with shorter payload to keep it under 16kb

resolves #319 