### PR TITLE
Add daily energy supply cost sensors

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,18 @@ _Some generic/summary sensors_
    - Gas delivery costs today (excl. tax): `€` _(when there is a Zonneplan gas contract and a gas meter registered in the P1 reader, default disabled)_
 
 
+- Daily energy supply costs _(available when there is a Zonneplan Energy contract)_
+
+   These match the daily costs shown in the app, so they exclude battery trading.
+   Note that production costs are **negative** here (revenue), while the month/year sensors below
+   report the same revenue as a positive number; each mirrors the sign of the API it comes from.
+
+   - Net delivery costs today `€` _(default disabled)_
+   - Net delivery costs today (excl. tax) `€` _(default disabled)_
+   - Net production costs today `€` _(default disabled)_
+   - Net production costs today (excl. tax) `€` _(default disabled)_
+
+
 - Net values _(available when there is a Zonneplan Battery)_
 
    - Net delivery costs this month `€` _(default disabled)_

--- a/custom_components/zonneplan_one/__init__.py
+++ b/custom_components/zonneplan_one/__init__.py
@@ -22,6 +22,7 @@ from .const import (
     ELECTRICITY,
     ELECTRICITY_HOME_CONSUMPTION,
     ELECTRICITY_PRICES,
+    ENERGY_SUPPLY_COSTS,
     GAS,
     GAS_PRICES,
     P1_ELECTRICITY,
@@ -46,6 +47,9 @@ from .coordinators.electricity_home_consumption_data_coordinator import (
     ElectricityHomeConsumptionDataUpdateCoordinator,
 )
 from .coordinators.electricity_prices_data_coordinator import ElectricityPricesDataUpdateCoordinator
+from .coordinators.energy_supply_costs_data_coordinator import (
+    EnergySupplyCostsDataUpdateCoordinator,
+)
 from .coordinators.gas_data_coordinator import GasDataUpdateCoordinator
 from .coordinators.gas_prices_data_coordinator import GasPricesDataUpdateCoordinator
 from .coordinators.pv_data_coordinator import PvDataUpdateCoordinator
@@ -138,6 +142,22 @@ async def async_setup_entry(hass: HomeAssistant, entry: ZonneplanConfigEntry) ->
                         contracts[ELECTRICITY][0],
                     ),
                 )
+
+                if organization_uuid := address_group.get("organization_uuid"):
+                    account_coordinator.add_coordinator(
+                        connection["uuid"],
+                        ENERGY_SUPPLY_COSTS,
+                        EnergySupplyCostsDataUpdateCoordinator(
+                            hass,
+                            zonneplan_api,
+                            address_group["uuid"],
+                            connection["uuid"],
+                            organization_uuid,
+                            contracts[ELECTRICITY][0],
+                        ),
+                    )
+                else:
+                    _LOGGER.info("Skipped ENERGY_SUPPLY_COSTS because the address group has no organization_uuid")
 
             if GAS in contracts:
                 account_coordinator.add_coordinator(

--- a/custom_components/zonneplan_one/__init__.py
+++ b/custom_components/zonneplan_one/__init__.py
@@ -151,10 +151,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ZonneplanConfigEntry) ->
                         EnergySupplyCostsDataUpdateCoordinator(
                             hass,
                             zonneplan_api,
-                            address_group["uuid"],
+                            address_group["address"]["id"],
                             connection["uuid"],
                             organization_uuid,
-                            contracts[ELECTRICITY][0],
                         ),
                     )
                 else:

--- a/custom_components/zonneplan_one/__init__.py
+++ b/custom_components/zonneplan_one/__init__.py
@@ -152,6 +152,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ZonneplanConfigEntry) ->
                             hass,
                             zonneplan_api,
                             address_group["address"]["id"],
+                            address_group["uuid"],
                             connection["uuid"],
                             organization_uuid,
                         ),

--- a/custom_components/zonneplan_one/api.py
+++ b/custom_components/zonneplan_one/api.py
@@ -69,7 +69,7 @@ class AsyncConfigEntryAuth(ZonneplanApi):
     async def async_get_energy_supply_costs(
         self,
         organization_uuid: str,
-        address_uuid: str,
+        address_id: str,
         start_date: date,
         end_date: date,
         *,
@@ -77,7 +77,7 @@ class AsyncConfigEntryAuth(ZonneplanApi):
     ) -> dict | None:
         """Get energy supply costs for the given address and date range."""
         return await self._async_get(
-            f"api/organizations/{organization_uuid}/addresses/{address_uuid}/energy-supply/costs"
+            f"api/organizations/{organization_uuid}/addresses/{address_id}/energy-supply/costs"
             f"?start_date={start_date.isoformat()}&end_date={end_date.isoformat()}",
             ignore_etag=ignore_etag,
         )

--- a/custom_components/zonneplan_one/api.py
+++ b/custom_components/zonneplan_one/api.py
@@ -66,6 +66,22 @@ class AsyncConfigEntryAuth(ZonneplanApi):
     async def async_get(self, connection_uuid: str, path: str, *, ignore_etag: bool = False) -> dict | None:
         return await self._async_get("connections/" + connection_uuid + path, ignore_etag=ignore_etag)
 
+    async def async_get_energy_supply_costs(
+        self,
+        organization_uuid: str,
+        address_uuid: str,
+        start_date: date,
+        end_date: date,
+        *,
+        ignore_etag: bool = False,
+    ) -> dict | None:
+        """Get energy supply costs for the given address and date range."""
+        return await self._async_get(
+            f"api/organizations/{organization_uuid}/addresses/{address_uuid}/energy-supply/costs"
+            f"?start_date={start_date.isoformat()}&end_date={end_date.isoformat()}",
+            ignore_etag=ignore_etag,
+        )
+
     async def async_get_battery_chart(self, contract_uuid: str, chart: str, chart_date: date) -> dict | None:
         """Get battery chart data for the given contract and date."""
         chart_date_str = chart_date.isoformat()

--- a/custom_components/zonneplan_one/const.py
+++ b/custom_components/zonneplan_one/const.py
@@ -43,6 +43,7 @@ P1_INSTALL = "p1_installation"
 P1_ELECTRICITY = "p1_electricity"
 P1_GAS = "p1_gas"
 ELECTRICITY_HOME_CONSUMPTION = "electricity_home_consumption"
+ENERGY_SUPPLY_COSTS = "energy_supply_costs"
 CHARGE_POINT = "charge_point_installation"
 BATTERY = "home_battery_installation"
 BATTERY_CONTROL = "battery_control"
@@ -1168,6 +1169,56 @@ SENSOR_TYPES: dict[
                     label="days",
                 ),
             ],
+        ),
+    },
+    ENERGY_SUPPLY_COSTS: {
+        # `usage_costs.electricity_costs` holds the contracted (battery filtered) costs,
+        # matching the daily figure the Zonneplan app shows. Note production costs come
+        # back negative here (revenue), unlike the measurement_groups meta used by the
+        # month/year sensors, which reports the same revenue positive.
+        "delivery_costs_today": ZonneplanSensorEntityDescription(
+            key="usage_costs.electricity_costs.delivery_costs.amount",
+            name="Net delivery costs today",
+            translation_key="delivery_costs_today",
+            native_unit_of_measurement=CURRENCY_EURO,
+            device_class=SensorDeviceClass.MONETARY,
+            state_class=SensorStateClass.TOTAL,
+            value_factor=0.0000001,
+            none_value_behaviour=NONE_IS_ZERO,
+            last_reset_key="date",
+        ),
+        "delivery_costs_excl_tax_today": ZonneplanSensorEntityDescription(
+            key="usage_costs.electricity_costs.delivery_costs_tax_excluded.amount",
+            name="Net delivery costs today (excl. tax)",
+            translation_key="delivery_costs_today_excl_tax",
+            native_unit_of_measurement=CURRENCY_EURO,
+            device_class=SensorDeviceClass.MONETARY,
+            state_class=SensorStateClass.TOTAL,
+            value_factor=0.0000001,
+            none_value_behaviour=NONE_IS_ZERO,
+            last_reset_key="date",
+        ),
+        "production_costs_today": ZonneplanSensorEntityDescription(
+            key="usage_costs.electricity_costs.production_costs.amount",
+            name="Net production costs today",
+            translation_key="production_costs_today",
+            native_unit_of_measurement=CURRENCY_EURO,
+            device_class=SensorDeviceClass.MONETARY,
+            state_class=SensorStateClass.TOTAL,
+            value_factor=0.0000001,
+            none_value_behaviour=NONE_IS_ZERO,
+            last_reset_key="date",
+        ),
+        "production_costs_excl_tax_today": ZonneplanSensorEntityDescription(
+            key="usage_costs.electricity_costs.production_costs_tax_excluded.amount",
+            name="Net production costs today (excl. tax)",
+            translation_key="production_costs_today_excl_tax",
+            native_unit_of_measurement=CURRENCY_EURO,
+            device_class=SensorDeviceClass.MONETARY,
+            state_class=SensorStateClass.TOTAL,
+            value_factor=0.0000001,
+            none_value_behaviour=NONE_IS_ZERO,
+            last_reset_key="date",
         ),
     },
     ELECTRICITY_HOME_CONSUMPTION: {

--- a/custom_components/zonneplan_one/coordinators/account_data_coordinator.py
+++ b/custom_components/zonneplan_one/coordinators/account_data_coordinator.py
@@ -24,6 +24,7 @@ from .electricity_home_consumption_data_coordinator import (
     ElectricityHomeConsumptionDataUpdateCoordinator,
 )
 from .electricity_prices_data_coordinator import ElectricityPricesDataUpdateCoordinator
+from .energy_supply_costs_data_coordinator import EnergySupplyCostsDataUpdateCoordinator
 from .gas_data_coordinator import GasDataUpdateCoordinator
 from .gas_prices_data_coordinator import GasPricesDataUpdateCoordinator
 from .pv_data_coordinator import PvDataUpdateCoordinator
@@ -45,6 +46,7 @@ class ConnectionCoordinators:
     p1_electricity: ElectricityDataUpdateCoordinator | None = None
     p1_gas: GasDataUpdateCoordinator | None = None
     electricity_home_consumption: ElectricityHomeConsumptionDataUpdateCoordinator | None = None
+    energy_supply_costs: EnergySupplyCostsDataUpdateCoordinator | None = None
     charge_point_installation: ChargePointDataUpdateCoordinator | None = None
     home_battery_installation: BatteryDataUpdateCoordinator | None = None
     battery_control: BatteryControlDataUpdateCoordinator | None = None

--- a/custom_components/zonneplan_one/coordinators/energy_supply_costs_data_coordinator.py
+++ b/custom_components/zonneplan_one/coordinators/energy_supply_costs_data_coordinator.py
@@ -9,7 +9,7 @@ from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.debounce import Debouncer
 
 from ..api import AsyncConfigEntryAuth
-from ..const import DOMAIN
+from ..const import DOMAIN, ZONNEPLAN_API_TIME_ZONE
 from ..zonneplan_api.types import ZonneplanContract
 from .zonneplan_data_update_coordinator import ZonneplanDataUpdateCoordinator
 
@@ -29,17 +29,16 @@ class EnergySupplyCostsDataUpdateCoordinator(ZonneplanDataUpdateCoordinator):
     hass: HomeAssistant
     api: AsyncConfigEntryAuth
     contract: ZonneplanContract
-    address_uuid: str
+    address_id: str
     organization_uuid: str
 
     def __init__(
         self,
         hass: HomeAssistant,
         api: AsyncConfigEntryAuth,
-        address_uuid: str,
+        address_id: str,
         connection_uuid: str,
         organization_uuid: str,
-        contract: ZonneplanContract,
     ) -> None:
         """Initialize."""
         super().__init__(
@@ -51,20 +50,18 @@ class EnergySupplyCostsDataUpdateCoordinator(ZonneplanDataUpdateCoordinator):
         )
 
         self.api: AsyncConfigEntryAuth = api
-        self.address_uuid = address_uuid
+        self.address_id = address_id
         self.connection_uuid = connection_uuid
         self.organization_uuid = organization_uuid
-        self.contract = contract
-        self._zonneplan_api_time_zone = dt_util.get_time_zone("Europe/Amsterdam")
 
     async def _async_update_data(self) -> dict:
         """Fetch the latest status."""
-        start_of_today = dt_util.now(self._zonneplan_api_time_zone).replace(hour=0, minute=0, second=0, microsecond=0)
+        start_of_today = dt_util.now(ZONNEPLAN_API_TIME_ZONE).replace(hour=0, minute=0, second=0, microsecond=0)
 
         try:
             costs = await self.api.async_get_energy_supply_costs(
                 self.organization_uuid,
-                self.address_uuid,
+                self.address_id,
                 start_of_today.date(),
                 start_of_today.date(),
             )

--- a/custom_components/zonneplan_one/coordinators/energy_supply_costs_data_coordinator.py
+++ b/custom_components/zonneplan_one/coordinators/energy_supply_costs_data_coordinator.py
@@ -30,6 +30,7 @@ class EnergySupplyCostsDataUpdateCoordinator(ZonneplanDataUpdateCoordinator):
     api: AsyncConfigEntryAuth
     contract: ZonneplanContract
     address_id: str
+    address_uuid: str
     organization_uuid: str
 
     def __init__(
@@ -37,6 +38,7 @@ class EnergySupplyCostsDataUpdateCoordinator(ZonneplanDataUpdateCoordinator):
         hass: HomeAssistant,
         api: AsyncConfigEntryAuth,
         address_id: str,
+        address_uud: str,
         connection_uuid: str,
         organization_uuid: str,
     ) -> None:
@@ -51,6 +53,7 @@ class EnergySupplyCostsDataUpdateCoordinator(ZonneplanDataUpdateCoordinator):
 
         self.api: AsyncConfigEntryAuth = api
         self.address_id = address_id
+        self.address_uuid = address_uud
         self.connection_uuid = connection_uuid
         self.organization_uuid = organization_uuid
 

--- a/custom_components/zonneplan_one/coordinators/energy_supply_costs_data_coordinator.py
+++ b/custom_components/zonneplan_one/coordinators/energy_supply_costs_data_coordinator.py
@@ -17,7 +17,8 @@ _LOGGER = logging.getLogger(__name__)
 
 
 class EnergySupplyCostsDataUpdateCoordinator(ZonneplanDataUpdateCoordinator):
-    """Zonneplan energy supply costs data update coordinator.
+    """
+    Zonneplan energy supply costs data update coordinator.
 
     Unlike the other coordinators this one is address scoped instead of connection
     scoped, and it asks for a single explicit day (today in the Zonneplan API time

--- a/custom_components/zonneplan_one/coordinators/energy_supply_costs_data_coordinator.py
+++ b/custom_components/zonneplan_one/coordinators/energy_supply_costs_data_coordinator.py
@@ -1,0 +1,83 @@
+import logging
+from datetime import timedelta
+from http import HTTPStatus
+
+import homeassistant.util.dt as dt_util
+from aiohttp.client_exceptions import ClientResponseError
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryAuthFailed
+from homeassistant.helpers.debounce import Debouncer
+
+from ..api import AsyncConfigEntryAuth
+from ..const import DOMAIN
+from ..zonneplan_api.types import ZonneplanContract
+from .zonneplan_data_update_coordinator import ZonneplanDataUpdateCoordinator
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class EnergySupplyCostsDataUpdateCoordinator(ZonneplanDataUpdateCoordinator):
+    """Zonneplan energy supply costs data update coordinator.
+
+    Unlike the other coordinators this one is address scoped instead of connection
+    scoped, and it asks for a single explicit day (today in the Zonneplan API time
+    zone). These are the battery-filtered costs the app shows on its daily overview;
+    the `/electricity-home-consumption` payload only carries them per month/year.
+    """
+
+    hass: HomeAssistant
+    api: AsyncConfigEntryAuth
+    contract: ZonneplanContract
+    address_uuid: str
+    organization_uuid: str
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        api: AsyncConfigEntryAuth,
+        address_uuid: str,
+        connection_uuid: str,
+        organization_uuid: str,
+        contract: ZonneplanContract,
+    ) -> None:
+        """Initialize."""
+        super().__init__(
+            hass,
+            _LOGGER,
+            name=DOMAIN,
+            update_interval=timedelta(seconds=300),
+            request_refresh_debouncer=Debouncer(hass, _LOGGER, cooldown=60, immediate=False),
+        )
+
+        self.api: AsyncConfigEntryAuth = api
+        self.address_uuid = address_uuid
+        self.connection_uuid = connection_uuid
+        self.organization_uuid = organization_uuid
+        self.contract = contract
+        self._zonneplan_api_time_zone = dt_util.get_time_zone("Europe/Amsterdam")
+
+    async def _async_update_data(self) -> dict:
+        """Fetch the latest status."""
+        start_of_today = dt_util.now(self._zonneplan_api_time_zone).replace(hour=0, minute=0, second=0, microsecond=0)
+
+        try:
+            costs = await self.api.async_get_energy_supply_costs(
+                self.organization_uuid,
+                self.address_uuid,
+                start_of_today.date(),
+                start_of_today.date(),
+            )
+
+        except ClientResponseError as e:
+            if e.status == HTTPStatus.UNAUTHORIZED:
+                raise ConfigEntryAuthFailed from e
+            raise
+        else:
+            _LOGGER.debug("Energy supply costs data: %s", costs)
+
+            if not costs:
+                return self.data
+
+            # The response carries no date of its own, so stamp the day it covers to
+            # give the daily cost sensors a last_reset.
+            return {"date": start_of_today.isoformat(), **costs}

--- a/custom_components/zonneplan_one/sensor.py
+++ b/custom_components/zonneplan_one/sensor.py
@@ -30,6 +30,7 @@ from .const import (
     ELECTRICITY,
     ELECTRICITY_HOME_CONSUMPTION,
     ELECTRICITY_PRICES,
+    ENERGY_SUPPLY_COSTS,
     GAS_PRICES,
     NONE_IS_ZERO,
     NONE_USE_PREVIOUS,
@@ -56,6 +57,9 @@ from .coordinators.electricity_home_consumption_data_coordinator import (
     ElectricityHomeConsumptionDataUpdateCoordinator,
 )
 from .coordinators.electricity_prices_data_coordinator import ElectricityPricesDataUpdateCoordinator
+from .coordinators.energy_supply_costs_data_coordinator import (
+    EnergySupplyCostsDataUpdateCoordinator,
+)
 from .coordinators.gas_data_coordinator import GasDataUpdateCoordinator
 from .coordinators.gas_prices_data_coordinator import GasPricesDataUpdateCoordinator
 from .coordinators.pv_data_coordinator import PvDataUpdateCoordinator
@@ -148,6 +152,18 @@ async def async_setup_entry(
                     SENSOR_TYPES[BATTERY_CHARTS][sensor_key],
                 )
                 for sensor_key in SENSOR_TYPES[BATTERY_CHARTS]
+            )
+
+        if connection.energy_supply_costs:
+            entities.extend(
+                ZonneplanEnergySupplyCostsSensor(
+                    uuid,
+                    sensor_key,
+                    connection.energy_supply_costs,
+                    -1,
+                    SENSOR_TYPES[ENERGY_SUPPLY_COSTS][sensor_key],
+                )
+                for sensor_key in SENSOR_TYPES[ENERGY_SUPPLY_COSTS]
             )
 
         if connection.electricity_home_consumption:
@@ -524,6 +540,33 @@ class ZonneplanElectricityHomeConsumptionSensor(ZonneplanSensor):
         connection_uuid: str,
         sensor_key: str,
         coordinator: ElectricityHomeConsumptionDataUpdateCoordinator,
+        install_index: int,
+        description: ZonneplanSensorEntityDescription,
+    ) -> None:
+        """Initialize the sensor."""
+        super().__init__(connection_uuid, sensor_key, coordinator, install_index, description)
+
+        self.entity_id = f"sensor.zonneplan_{sensor_key}"
+
+    @property
+    def install_uuid(self) -> str:
+        """Return install ID."""
+        return self._connection_uuid
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return the device information."""
+        return base_device_info(self.coordinator.address_uuid)
+
+
+class ZonneplanEnergySupplyCostsSensor(ZonneplanSensor):
+    coordinator: EnergySupplyCostsDataUpdateCoordinator
+
+    def __init__(
+        self,
+        connection_uuid: str,
+        sensor_key: str,
+        coordinator: EnergySupplyCostsDataUpdateCoordinator,
         install_index: int,
         description: ZonneplanSensorEntityDescription,
     ) -> None:

--- a/custom_components/zonneplan_one/sensor.py
+++ b/custom_components/zonneplan_one/sensor.py
@@ -581,7 +581,7 @@ class ZonneplanEnergySupplyCostsSensor(ZonneplanSensor):
     @property
     def device_info(self) -> DeviceInfo:
         """Return the device information."""
-        return base_device_info(self.coordinator.address_id)
+        return base_device_info(self.coordinator.address_uuid)
 
 
 class ZonneplanPvSensor(PvEntity, ZonneplanSensor):

--- a/custom_components/zonneplan_one/sensor.py
+++ b/custom_components/zonneplan_one/sensor.py
@@ -581,7 +581,7 @@ class ZonneplanEnergySupplyCostsSensor(ZonneplanSensor):
     @property
     def device_info(self) -> DeviceInfo:
         """Return the device information."""
-        return base_device_info(self.coordinator.address_uuid)
+        return base_device_info(self.coordinator.address_id)
 
 
 class ZonneplanPvSensor(PvEntity, ZonneplanSensor):

--- a/custom_components/zonneplan_one/strings.json
+++ b/custom_components/zonneplan_one/strings.json
@@ -299,11 +299,17 @@
       "charge_point_session_charged_distance": {
         "name": "Charge point session charged distance"
       },
+      "delivery_costs_today": {
+        "name": "Net delivery costs today"
+      },
       "delivery_costs_this_month": {
         "name": "Net delivery costs this month"
       },
       "delivery_costs_this_year": {
         "name": "Net delivery costs this year"
+      },
+      "production_costs_today": {
+        "name": "Net production costs today"
       },
       "production_costs_this_month": {
         "name": "Net production costs this month"

--- a/custom_components/zonneplan_one/translations/nl.json
+++ b/custom_components/zonneplan_one/translations/nl.json
@@ -428,6 +428,12 @@
       "charge_point_session_charged_distance": {
         "name": "Laadpaal sessie geladen afstand"
       },
+      "delivery_costs_today": {
+        "name": "Netto afname vandaag"
+      },
+      "delivery_costs_today_excl_tax": {
+        "name": "Netto afname vandaag (excl. btw)"
+      },
       "delivery_costs_this_month": {
         "name": "Netto afname deze maand"
       },
@@ -440,10 +446,16 @@
       "delivery_costs_this_year_excl_tax": {
         "name": "Netto afname dit jaar (excl. btw)"
       },
+      "production_costs_today": {
+        "name": "Netto teruggeleverd vandaag"
+      },
+      "production_costs_today_excl_tax": {
+        "name": "Netto teruggeleverd vandaag (excl. btw)"
+      },
       "production_costs_this_month": {
         "name": "Netto teruggeleverd deze maand"
       },
-      "production_costs__this_monthexcl_tax": {
+      "production_costs_this_month_excl_tax": {
         "name": "Netto teruggeleverd deze maand (excl. btw)"
       },
       "production_costs_this_year": {


### PR DESCRIPTION
Fixes #340

## Why

Battery owners get `Net delivery/production costs this month` and `this year`, which match the app, but there is no `today` equivalent. The existing `Electricity delivery/production costs today` sensors are not a substitute they read `/electricity-delivered`, i.e. the P1 meter total *including* battery charging and discharging, so for a battery household they differ from the daily figure the app shows. That difference is the actual complaint in #340.

## Why not the obvious fix

`/electricity-home-consumption` is the battery-filtered counterpart, so adding group-0 sensors there looked like the natural one-line change. It does not work, verified against a diagnostics dump:

```
electricity_home_consumption.measurement_groups
  [0] type "live"    measurements: []  totals: []  labels: []   <- no `meta` at all
  [1] type "hours"   measurements: []  totals: []  labels: []   <- no `meta` at all
  [2] type "days"    meta: { delivery_costs_incl_tax, ... }     <- this month
  [3] type "months"  meta: { delivery_costs_incl_tax, ... }     <- this year
```

`/electricity-delivered` populates cost meta on both of its first two groups, which is why the P1 family works; the home-consumption endpoint leaves them empty. Its per-day entries in group 2 only hold `result_tax_included/excluded`, a single combined net figure with no delivery/production split so keying on them would have silently reported `0.00` rather than going unavailable.

## What this does

Adds a coordinator for `energy-supply/costs`, the endpoint the app itself calls, and exposes four default-disabled sensors on the Zonneplan device:

- Net delivery costs today (+ excl. tax)
- Net production costs today (+ excl. tax)

Guarded on an Energy contract, not on a battery: `asset_costs` in that response carries parallel `home_battery`, `pv_system` and `charge_point` sections, so it reads as a generic supply-cost endpoint. Happy to gate it on `BATTERY` instead if you know otherwise.

Two things worth a look in review:

- **Scope.** The endpoint is address scoped (`api/organizations/{org}/addresses/{addr}/...`) and takes an explicit day, so the coordinator requests today in `Europe/Amsterdam` and stamps that date onto the payload to give the sensors a `last_reset`. The date being in the URL also means a new day never gets a 304 against the previous day's ETag. Registration stays connection-keyed, so `ConnectionCoordinators`, diagnostics and `ZonneplanSensor` are untouched.
- **Sign.** Production costs come back **negative** here (revenue), matching the app, whereas the `measurement_groups` meta behind the month/year sensors reports the same revenue positive. I kept each endpoint's own sign, consistent with how #291 was resolved, and called it out in the README.

Also fixes a typo'd key in `translations/nl.json` (`production_costs__this_monthexcl_tax`), which meant the Dutch name for `Net production costs this month (excl. tax)` never resolved.

## Verification

Values were checked by replaying a real `energy-supply/costs` response through `get_data_value` + `value_factor`:

| sensor | raw | state |
| --- | --- | --- |
| `sensor.zonneplan_delivery_costs_today` | `5413414` | €+0.5413 |
| `sensor.zonneplan_delivery_costs_excl_tax_today` | `3394871` | €+0.3395 |
| `sensor.zonneplan_production_costs_today` | `-2499614` | €−0.2500 |
| `sensor.zonneplan_production_costs_excl_tax_today` | `-1554080` | €−0.1554 |

Delivery + production = €+0.2914, which equals the API's own `usage_costs.electricity_costs.aggregate.electricity_usage_costs`. The same dump also confirms the two families measure different things: `/electricity-delivered` totals (8112 / 17175 Wh) track `*_measured_volume` (7764 / 17146), while home-consumption (2169 / 882) tracks `contracted_*_volume` (1821 / 853).
