### PR TITLE
Add continue auto charging button for charge points

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,11 @@ _Sensors available if you have a Zonneplan charge point/laadpaal_
 - Charge point dynamic charging flex suppressed `on/off` _(default disabled)_
 - Charge on solar enabled `on/off`
 - Buttons to start/stop charge
+- Button to continue auto charging
+  - Equivalent of _Automatisch laden voortzetten_ in the app. Stopping a manual charge suppresses
+    automatic (Powerplay flex) charging until this is pressed, so the charge point will not pick up
+    cheap/solar charging again on its own.
+  - Only available while `Charge point dynamic charging flex suppressed` is on, mirroring the app.
 
 ### Zonneplan Battery
 _Sensors available if you have a Zonneplan Nexus battery_

--- a/custom_components/zonneplan_one/button.py
+++ b/custom_components/zonneplan_one/button.py
@@ -92,18 +92,12 @@ class ZonneplanChargePointButton(ChargePointEntity, CoordinatorEntity, ButtonEnt
         if "processing" in state:
             return False
 
-        if self._button_key == "start":
-            return state["state"] == "VehicleDetected"
-
-        if self._button_key == "stop":
-            return state["state"] == "Charging"
-
         if self._button_key == "continue_auto_charging":
             # Mirror the app, which only offers this while automatic charging is
             # suppressed, which is what stopping a manual charge does.
             return bool(state.get("dynamic_charging_flex_suppressed"))
 
-        return False
+        return state["state"] == {"start": "VehicleDetected", "stop": "Charging"}.get(self._button_key)
 
     async def async_press(self) -> None:
         """Handle the button press."""

--- a/custom_components/zonneplan_one/button.py
+++ b/custom_components/zonneplan_one/button.py
@@ -92,10 +92,18 @@ class ZonneplanChargePointButton(ChargePointEntity, CoordinatorEntity, ButtonEnt
         if "processing" in state:
             return False
 
-        if self._button_key == "stop" and state["state"] == "Charging":
-            return True
+        if self._button_key == "start":
+            return state["state"] == "VehicleDetected"
 
-        return bool(self._button_key == "start" and state["state"] == "VehicleDetected")
+        if self._button_key == "stop":
+            return state["state"] == "Charging"
+
+        if self._button_key == "continue_auto_charging":
+            # Mirror the app, which only offers this while automatic charging is
+            # suppressed, which is what stopping a manual charge does.
+            return bool(state.get("dynamic_charging_flex_suppressed"))
+
+        return False
 
     async def async_press(self) -> None:
         """Handle the button press."""
@@ -103,5 +111,7 @@ class ZonneplanChargePointButton(ChargePointEntity, CoordinatorEntity, ButtonEnt
             await self.coordinator.async_start_charge()
         elif self._button_key == "stop":
             await self.coordinator.async_stop_charge()
+        elif self._button_key == "continue_auto_charging":
+            await self.coordinator.async_continue_auto_charging()
         else:
             _LOGGER.warning("Unknown button action for %s", self._button_key)

--- a/custom_components/zonneplan_one/const.py
+++ b/custom_components/zonneplan_one/const.py
@@ -1617,6 +1617,11 @@ BUTTON_TYPES: dict[str, dict[str, ZonneplanButtonEntityDescription]] = {
             name="Stop charge",
             translation_key="stop_charge",
         ),
+        "continue_auto_charging": ZonneplanButtonEntityDescription(
+            key="charge_point.continue_auto_charging",
+            name="Continue auto charging",
+            translation_key="continue_auto_charging",
+        ),
     },
 }
 

--- a/custom_components/zonneplan_one/coordinators/charge_point_data_coordinator.py
+++ b/custom_components/zonneplan_one/coordinators/charge_point_data_coordinator.py
@@ -97,6 +97,18 @@ class ChargePointDataUpdateCoordinator(ZonneplanDataUpdateCoordinator):
 
         await self.async_fetch_charge_point_data()
 
+    async def async_continue_auto_charging(self) -> None:
+        await self.api.async_post(
+            self.connection_uuid,
+            "/charge-points/" + self.contract["uuid"] + "/actions/unsuppress_always_flex",
+        )
+
+        self.data["state"]["processing"] = True
+
+        self.async_update_listeners()
+
+        await self.async_fetch_charge_point_data()
+
     def _processing_charge_point_update(self) -> bool:
         processing = self.data.get("state", {}).get("processing")
 

--- a/custom_components/zonneplan_one/strings.json
+++ b/custom_components/zonneplan_one/strings.json
@@ -398,6 +398,9 @@
       },
       "stop_charge": {
         "name": "Stop charge"
+      },
+      "continue_auto_charging": {
+        "name": "Continue auto charging"
       }
     },
     "number": {

--- a/custom_components/zonneplan_one/translations/nl.json
+++ b/custom_components/zonneplan_one/translations/nl.json
@@ -545,6 +545,9 @@
       },
       "stop_charge": {
         "name": "Stop laden"
+      },
+      "continue_auto_charging": {
+        "name": "Automatisch laden voortzetten"
       }
     },
     "number": {


### PR DESCRIPTION
Implements the request in #253.

## Why

`Stop charge` does more than end the session, it also **suppresses automatic charging**. After a manual stop the charge point will not pick up cheap or solar (Powerplay flex) charging again until you either replug the cable or press *Automatisch laden voortzetten* in the app. That is easy to miss, and as noted in the discussion it silently costs you free solar charging.

There was no way to resume it from Home Assistant, so a manual stop effectively took the charge point out of automatic mode until someone opened the app.

## What this adds

A third charge point button calling the endpoint the app uses:

```
POST connections/{connection_uuid}/charge-points/{charge_point_uuid}/actions/unsuppress_always_flex
```

No body, so it goes through the existing `async_post` helper exactly like `start_boost` and `stop_charging`. The coordinator reuses the existing optimistic `state["processing"] = True` + `async_fetch_charge_point_data()` pattern, so the button greys out until the poll confirms the new state.

- `Continue auto charging` / `Automatisch laden voortzetten`

## Availability

Tied to `state.dynamic_charging_flex_suppressed`, so the button only appears when there is something to un-suppress, the same condition under which the app shows it. That field is already exposed as the default-disabled `Charge point dynamic charging flex suppressed` binary sensor, which makes the natural automation straightforward: trigger on that sensor turning on, then press the button.

Worth confirming you are happy with that choice. Always-available would also be defensible, but conditional matches both the app and how `start`/`stop` already behave.

One trap from the discussion worth recording: `state.charging_automatically` (the `Charge point charging automatically` binary sensor) is **not** the suppression indicator. It stays off even after auto charging has been resumed in the app, which is what made this hard to spot from the existing entities.

## Refactor note

Adding a third branch made the combined availability expression awkward, so it is now one condition per button:

```python
if self._button_key == "start":
    return state["state"] == "VehicleDetected"

if self._button_key == "stop":
    return state["state"] == "Charging"

if self._button_key == "continue_auto_charging":
    return bool(state.get("dynamic_charging_flex_suppressed"))

return False
```

I checked this against the old expression across all 72 combinations of `connectivity_state`, `state`, `dynamic_charging_flex_suppressed` and `processing`: `start` and `stop` are unchanged in every case.
