### PR TITLE
Change start_date and end_date to use datetime object

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,6 +8,7 @@ insert_final_newline = true
 # Remove trailing whitespace (matches "files.trimTrailingWhitespace": true)
 trim_trailing_whitespace = true
 charset = utf-8
+max_line_length = 160
 
 [*.{py,pyi}]
 # Python specific settings (matches "editor.tabSize": 4)

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,7 +1,7 @@
 # The contents of this file is based on https://github.com/home-assistant/core/blob/dev/pyproject.toml
 
 target-version = "py313"
-line-length = 140
+line-length = 160
 
 [lint]
 select = [

--- a/README.md
+++ b/README.md
@@ -282,12 +282,12 @@ From [discussions/41](https://github.com/fsaris/home-assistant-zonneplan-one/dis
 
 ```
 {% set cheapest_hour_next_twelve_hours = state_attr('sensor.zonneplan_current_hourly_electricity_tariff', 'forecast')
-  | selectattr('start_date', '>', utcnow().isoformat())
-  | selectattr('start_date', '<', (utcnow() + timedelta(hours = 11)).isoformat())
+  | selectattr('start_date', '>', now())
+  | selectattr('start_date', '<', (now() + timedelta(hours = 11)))
   | sort(attribute='price_tax_included.amount')
   | first %}
 
-{{ as_local(as_datetime(cheapest_hour_next_twelve_hours.start_date)) }}
+{{ cheapest_hour_next_twelve_hours.start_date }}
 ```
 </details>
 
@@ -300,46 +300,34 @@ From [discussions/41](https://github.com/fsaris/home-assistant-zonneplan-one/dis
 From [discussions/41](https://github.com/fsaris/home-assistant-zonneplan-one/discussions/41)
 
 ```
-{% set cheapest_hour_next_twelve_hours = state_attr('sensor.zonneplan_current_hourly_electricity_tariff', 'forecast')
-  | selectattr('start_date', '>', utcnow().isoformat())
-  | selectattr('start_date', '<', (utcnow() + timedelta(hours = 11)).isoformat())
-  | sort(attribute='price_tax_included.amount')
-  | first %}
-
-{{ as_local(as_datetime(cheapest_hour_next_twelve_hours.start_date)) }}
-
-{%- set timezone_offset = 2 %} {# Verander 2 naar je gewenste offset in uren #}
 {%- set cheapest_hour_next_fifteen_hours =
 state_attr('sensor.zonneplan_current_hourly_electricity_tariff', 'forecast') |
-selectattr('start_date', '>', utcnow().isoformat()) |
-selectattr('start_date', '<', (utcnow() + timedelta(hours = 15)).isoformat())
+selectattr('start_date', '>', now() - timedelta(hours = 1)) |
+selectattr('start_date', '<', (now() + timedelta(hours = 15)))
 | sort(attribute='price_tax_included.amount') %}
 {%- if cheapest_hour_next_fifteen_hours | length > 0 %}
   {%- set cheapest_hour = cheapest_hour_next_fifteen_hours | first %}
-  {%- set cheapest_hour_local_time = as_timestamp(as_datetime(cheapest_hour.start_date)) + timezone_offset * 3600 %}
-De goedkoopste tijd is {{ 'vandaag' if as_timestamp(utcnow())|timestamp_custom('%Y-%m-%d') == cheapest_hour_local_time|timestamp_custom('%Y-%m-%d') else 'morgen' }} om {{ (cheapest_hour_local_time)|timestamp_custom('%H') }} uur en kost €{{"{:.3f}".format(cheapest_hour.price_tax_excluded.amount|float/10000000) }}/kWh.
+  De goedkoopste tijd is {{ 'vandaag' if now().strftime('%Y-%m-%d') == cheapest_hour.start_date.strftime('%Y-%m-%d') else 'morgen' }} om {{ cheapest_hour.start_date.strftime('%H') }} uur en kost €{{"{:.3f}".format(cheapest_hour.price_tax_excluded.amount|float/10000000) }}/kWh.
 {% endif %}
 
 {%- set cheapest_forecast =
 state_attr('sensor.zonneplan_current_hourly_electricity_tariff', 'forecast') |
-selectattr('start_date', '>', utcnow().isoformat()) | selectattr('start_date',
-'<', (utcnow() + timedelta(hours = 15)).isoformat()) | list |
+selectattr('start_date', '>', now()) | selectattr('start_date',
+'<', (now() + timedelta(hours = 15))) | list |
 sort(attribute='price_tax_excluded.amount') | first %}
 
 {%- set expensive_forecast =
 state_attr('sensor.zonneplan_current_hourly_electricity_tariff', 'forecast') |
-selectattr('start_date', '>', utcnow().isoformat()) | selectattr('start_date',
-'<', (utcnow() + timedelta(hours = 15)).isoformat()) | list |
+selectattr('start_date', '>', now()) | selectattr('start_date',
+'<', (now() + timedelta(hours = 15))) | list |
 sort(attribute='price_tax_excluded.amount') | last %}
 
 {%- for forecast in
 state_attr('sensor.zonneplan_current_hourly_electricity_tariff', 'forecast') |
-selectattr('start_date', '>', utcnow().isoformat()) | selectattr('start_date',
-'<', (utcnow() + timedelta(hours = 15)).isoformat()) | list |
+selectattr('start_date', '>', now() - timedelta(hours = 1)) | selectattr('start_date',
+'<', (now() + timedelta(hours = 15))) | list |
 sort(attribute='start_date') %}
-
-{%- set forecast_local_time = as_timestamp(as_datetime(forecast.start_date)) + timezone_offset * 3600 %}
-• {{ (forecast_local_time)|timestamp_custom('%H:%M') }}    €{{ "{:.3f}".format(forecast.price_tax_included.amount / 10000000) }} (€{{ "{:.3f}".format(forecast.price_tax_excluded.amount / 10000000) }} excl.) {% if forecast == cheapest_forecast %}⭐{% endif %}{% if forecast == expensive_forecast %}🔴{% endif %}
+• {{ forecast.start_date.strftime('%H:%M') }}    €{{ "{:.3f}".format(forecast.price_tax_included.amount / 10000000) }} (€{{ "{:.3f}".format(forecast.price_tax_excluded.amount / 10000000) }} excl.) {% if forecast == cheapest_forecast %}⭐{% endif %}{% if forecast == expensive_forecast %}🔴{% endif %}
 {%- endfor %}
 ```
 

--- a/custom_components/zonneplan_one/const.py
+++ b/custom_components/zonneplan_one/const.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import UTC, datetime, timedelta
+from datetime import datetime, timedelta
 from typing import TYPE_CHECKING
 
 import homeassistant.util.dt as dt_util
@@ -52,6 +52,8 @@ NONE_IS_ZERO = "none-is-zero"
 NONE_USE_PREVIOUS = "none-is-previous"
 GAS_NEXT_PRICE_HOUR = 6
 VERSION = "2026.7.2"
+
+ZONNEPLAN_API_TIME_ZONE = dt_util.get_time_zone("Europe/Amsterdam")
 
 
 @dataclass
@@ -108,13 +110,8 @@ class ZonneplanSelectEntityDescription(SelectEntityDescription):
 
 def get_gas_hour(param: str) -> str:
     """Get gas date_hour key."""
-    zonneplan_api_time_zone = dt_util.get_time_zone("Europe/Amsterdam")
-    now = dt_util.now(zonneplan_api_time_zone)
-    start = (
-        now.replace(hour=GAS_NEXT_PRICE_HOUR)
-        if now.hour >= GAS_NEXT_PRICE_HOUR
-        else (now - timedelta(days=1)).replace(hour=GAS_NEXT_PRICE_HOUR)
-    )
+    now = dt_util.now(ZONNEPLAN_API_TIME_ZONE)
+    start = now.replace(hour=GAS_NEXT_PRICE_HOUR) if now.hour >= GAS_NEXT_PRICE_HOUR else (now - timedelta(days=1)).replace(hour=GAS_NEXT_PRICE_HOUR)
     if param == "next":
         return (start + timedelta(days=1)).strftime("%Y-%m-%d %H")
     return start.strftime("%Y-%m-%d %H")
@@ -160,8 +157,8 @@ SENSOR_TYPES: dict[
             key="usage.sustainability_score",
             key_lambda=lambda: (
                 f"price_per_date_and_quarter_hour.{
-                    datetime.now(UTC)
-                    .replace(minute=(datetime.now(UTC).minute // 15) * 15, second=0, microsecond=0)
+                    datetime.now(ZONNEPLAN_API_TIME_ZONE)
+                    .replace(minute=(datetime.now(ZONNEPLAN_API_TIME_ZONE).minute // 15) * 15, second=0, microsecond=0)
                     .strftime('%Y-%m-%d %H:%M')
                 }.sustainability_score.permille"
             ),
@@ -175,13 +172,13 @@ SENSOR_TYPES: dict[
         ),
         "current_tariff_group": ZonneplanSensorEntityDescription(
             key="current_tariff_group",
-            key_lambda=lambda: f"price_per_date_and_hour.{(datetime.now(UTC)).strftime('%Y-%m-%d %H')}.tariff_group",
+            key_lambda=lambda: f"price_per_date_and_hour.{(datetime.now(ZONNEPLAN_API_TIME_ZONE)).strftime('%Y-%m-%d %H')}.tariff_group",
             name="Current tariff group",
             translation_key="current_tariff_group",
         ),
         "current_electricity_tariff": ZonneplanSensorEntityDescription(
             key="current_tariff",
-            key_lambda=lambda: f"price_per_date_and_hour.{datetime.now(UTC).strftime('%Y-%m-%d %H')}.electricity_price",
+            key_lambda=lambda: f"price_per_date_and_hour.{datetime.now(ZONNEPLAN_API_TIME_ZONE).strftime('%Y-%m-%d %H')}.electricity_price",
             name="Current electricity tariff",
             translation_key="current_electricity_tariff",
             icon="mdi:cash",
@@ -200,8 +197,8 @@ SENSOR_TYPES: dict[
             key="quarter_hourly_electricity_price",
             key_lambda=lambda: (
                 f"price_per_date_and_quarter_hour.{
-                    datetime.now(UTC)
-                    .replace(minute=(datetime.now(UTC).minute // 15) * 15, second=0, microsecond=0)
+                    datetime.now(ZONNEPLAN_API_TIME_ZONE)
+                    .replace(minute=(datetime.now(ZONNEPLAN_API_TIME_ZONE).minute // 15) * 15, second=0, microsecond=0)
                     .strftime('%Y-%m-%d %H:%M')
                 }.price_tax_included.amount"
             ),
@@ -222,7 +219,7 @@ SENSOR_TYPES: dict[
         ),
         "current_hourly_electricity_tariff": ZonneplanSensorEntityDescription(
             key="hourly_electricity_price",
-            key_lambda=lambda: f"price_per_date_and_hour.{datetime.now(UTC).strftime('%Y-%m-%d %H')}.electricity_price",
+            key_lambda=lambda: f"price_per_date_and_hour.{datetime.now(ZONNEPLAN_API_TIME_ZONE).strftime('%Y-%m-%d %H')}.electricity_price",
             name="Current hourly electricity tariff",
             translation_key="current_hourly_electricity_tariff",
             icon="mdi:cash",
@@ -240,7 +237,7 @@ SENSOR_TYPES: dict[
         "forecast_tariff_1": ZonneplanSensorEntityDescription(
             key="forecast_tariff_1",
             key_lambda=lambda: (
-                f"price_per_date_and_hour.{(datetime.now(UTC) + timedelta(hours=1)).strftime('%Y-%m-%d %H')}.electricity_price"
+                f"price_per_date_and_hour.{(datetime.now(ZONNEPLAN_API_TIME_ZONE) + timedelta(hours=1)).strftime('%Y-%m-%d %H')}.electricity_price"
             ),
             name="Forecast tariff hour 1",
             translation_key="forecast_tariff_hour_1",
@@ -252,7 +249,7 @@ SENSOR_TYPES: dict[
         "forecast_tariff_2": ZonneplanSensorEntityDescription(
             key="forecast_tariff_2",
             key_lambda=lambda: (
-                f"price_per_date_and_hour.{(datetime.now(UTC) + timedelta(hours=2)).strftime('%Y-%m-%d %H')}.electricity_price"
+                f"price_per_date_and_hour.{(datetime.now(ZONNEPLAN_API_TIME_ZONE) + timedelta(hours=2)).strftime('%Y-%m-%d %H')}.electricity_price"
             ),
             name="Forecast tariff hour 2",
             translation_key="forecast_tariff_hour_2",
@@ -264,7 +261,7 @@ SENSOR_TYPES: dict[
         "forecast_tariff_3": ZonneplanSensorEntityDescription(
             key="forecast_tariff_3",
             key_lambda=lambda: (
-                f"price_per_date_and_hour.{(datetime.now(UTC) + timedelta(hours=3)).strftime('%Y-%m-%d %H')}.electricity_price"
+                f"price_per_date_and_hour.{(datetime.now(ZONNEPLAN_API_TIME_ZONE) + timedelta(hours=3)).strftime('%Y-%m-%d %H')}.electricity_price"
             ),
             name="Forecast tariff hour 3",
             translation_key="forecast_tariff_hour_3",
@@ -276,7 +273,7 @@ SENSOR_TYPES: dict[
         "forecast_tariff_4": ZonneplanSensorEntityDescription(
             key="forecast_tariff_4",
             key_lambda=lambda: (
-                f"price_per_date_and_hour.{(datetime.now(UTC) + timedelta(hours=4)).strftime('%Y-%m-%d %H')}.electricity_price"
+                f"price_per_date_and_hour.{(datetime.now(ZONNEPLAN_API_TIME_ZONE) + timedelta(hours=4)).strftime('%Y-%m-%d %H')}.electricity_price"
             ),
             name="Forecast tariff hour 4",
             translation_key="forecast_tariff_hour_4",
@@ -288,7 +285,7 @@ SENSOR_TYPES: dict[
         "forecast_tariff_5": ZonneplanSensorEntityDescription(
             key="forecast_tariff_5",
             key_lambda=lambda: (
-                f"price_per_date_and_hour.{(datetime.now(UTC) + timedelta(hours=5)).strftime('%Y-%m-%d %H')}.electricity_price"
+                f"price_per_date_and_hour.{(datetime.now(ZONNEPLAN_API_TIME_ZONE) + timedelta(hours=5)).strftime('%Y-%m-%d %H')}.electricity_price"
             ),
             name="Forecast tariff hour 5",
             translation_key="forecast_tariff_hour_5",
@@ -300,7 +297,7 @@ SENSOR_TYPES: dict[
         "forecast_tariff_6": ZonneplanSensorEntityDescription(
             key="forecast_tariff_6",
             key_lambda=lambda: (
-                f"price_per_date_and_hour.{(datetime.now(UTC) + timedelta(hours=6)).strftime('%Y-%m-%d %H')}.electricity_price"
+                f"price_per_date_and_hour.{(datetime.now(ZONNEPLAN_API_TIME_ZONE) + timedelta(hours=6)).strftime('%Y-%m-%d %H')}.electricity_price"
             ),
             name="Forecast tariff hour 6",
             translation_key="forecast_tariff_hour_6",
@@ -312,7 +309,7 @@ SENSOR_TYPES: dict[
         "forecast_tariff_7": ZonneplanSensorEntityDescription(
             key="forecast_tariff_7",
             key_lambda=lambda: (
-                f"price_per_date_and_hour.{(datetime.now(UTC) + timedelta(hours=7)).strftime('%Y-%m-%d %H')}.electricity_price"
+                f"price_per_date_and_hour.{(datetime.now(ZONNEPLAN_API_TIME_ZONE) + timedelta(hours=7)).strftime('%Y-%m-%d %H')}.electricity_price"
             ),
             name="Forecast tariff hour 7",
             translation_key="forecast_tariff_hour_7",
@@ -324,7 +321,7 @@ SENSOR_TYPES: dict[
         "forecast_tariff_8": ZonneplanSensorEntityDescription(
             key="forecast_tariff_8",
             key_lambda=lambda: (
-                f"price_per_date_and_hour.{(datetime.now(UTC) + timedelta(hours=8)).strftime('%Y-%m-%d %H')}.electricity_price"
+                f"price_per_date_and_hour.{(datetime.now(ZONNEPLAN_API_TIME_ZONE) + timedelta(hours=8)).strftime('%Y-%m-%d %H')}.electricity_price"
             ),
             name="Forecast tariff hour 8",
             translation_key="forecast_tariff_hour_8",
@@ -335,50 +332,50 @@ SENSOR_TYPES: dict[
         ),
         "forecast_tariff_group_1": ZonneplanSensorEntityDescription(
             key="forecast_tariff_group_1",
-            key_lambda=lambda: f"price_per_date_and_hour.{(datetime.now(UTC) + timedelta(hours=1)).strftime('%Y-%m-%d %H')}.tariff_group",
+            key_lambda=lambda: f"price_per_date_and_hour.{(datetime.now(ZONNEPLAN_API_TIME_ZONE) + timedelta(hours=1)).strftime('%Y-%m-%d %H')}.tariff_group",
             name="Forecast tariff group hour 1",
             translation_key="forecast_tariff_group_hour_1",
             icon="mdi:cash",
         ),
         "forecast_tariff_group_2": ZonneplanSensorEntityDescription(
             key="forecast_tariff_group_2",
-            key_lambda=lambda: f"price_per_date_and_hour.{(datetime.now(UTC) + timedelta(hours=2)).strftime('%Y-%m-%d %H')}.tariff_group",
+            key_lambda=lambda: f"price_per_date_and_hour.{(datetime.now(ZONNEPLAN_API_TIME_ZONE) + timedelta(hours=2)).strftime('%Y-%m-%d %H')}.tariff_group",
             name="Forecast tariff group hour 2",
             translation_key="forecast_tariff_group_hour_2",
         ),
         "forecast_tariff_group_3": ZonneplanSensorEntityDescription(
             key="forecast_tariff_group_3",
-            key_lambda=lambda: f"price_per_date_and_hour.{(datetime.now(UTC) + timedelta(hours=3)).strftime('%Y-%m-%d %H')}.tariff_group",
+            key_lambda=lambda: f"price_per_date_and_hour.{(datetime.now(ZONNEPLAN_API_TIME_ZONE) + timedelta(hours=3)).strftime('%Y-%m-%d %H')}.tariff_group",
             name="Forecast tariff group hour 3",
             translation_key="forecast_tariff_group_hour_3",
         ),
         "forecast_tariff_group_4": ZonneplanSensorEntityDescription(
             key="forecast_tariff_group_4",
-            key_lambda=lambda: f"price_per_date_and_hour.{(datetime.now(UTC) + timedelta(hours=4)).strftime('%Y-%m-%d %H')}.tariff_group",
+            key_lambda=lambda: f"price_per_date_and_hour.{(datetime.now(ZONNEPLAN_API_TIME_ZONE) + timedelta(hours=4)).strftime('%Y-%m-%d %H')}.tariff_group",
             name="Forecast tariff group hour 4",
             translation_key="forecast_tariff_group_hour_4",
         ),
         "forecast_tariff_group_5": ZonneplanSensorEntityDescription(
             key="forecast_tariff_group_5",
-            key_lambda=lambda: f"price_per_date_and_hour.{(datetime.now(UTC) + timedelta(hours=5)).strftime('%Y-%m-%d %H')}.tariff_group",
+            key_lambda=lambda: f"price_per_date_and_hour.{(datetime.now(ZONNEPLAN_API_TIME_ZONE) + timedelta(hours=5)).strftime('%Y-%m-%d %H')}.tariff_group",
             name="Forecast tariff group hour 5",
             translation_key="forecast_tariff_group_hour_5",
         ),
         "forecast_tariff_group_6": ZonneplanSensorEntityDescription(
             key="forecast_tariff_group_6",
-            key_lambda=lambda: f"price_per_date_and_hour.{(datetime.now(UTC) + timedelta(hours=6)).strftime('%Y-%m-%d %H')}.tariff_group",
+            key_lambda=lambda: f"price_per_date_and_hour.{(datetime.now(ZONNEPLAN_API_TIME_ZONE) + timedelta(hours=6)).strftime('%Y-%m-%d %H')}.tariff_group",
             name="Forecast tariff group hour 6",
             translation_key="forecast_tariff_group_hour_6",
         ),
         "forecast_tariff_group_7": ZonneplanSensorEntityDescription(
             key="forecast_tariff_group_7",
-            key_lambda=lambda: f"price_per_date_and_hour.{(datetime.now(UTC) + timedelta(hours=7)).strftime('%Y-%m-%d %H')}.tariff_group",
+            key_lambda=lambda: f"price_per_date_and_hour.{(datetime.now(ZONNEPLAN_API_TIME_ZONE) + timedelta(hours=7)).strftime('%Y-%m-%d %H')}.tariff_group",
             name="Forecast tariff group hour 7",
             translation_key="forecast_tariff_group_hour_7",
         ),
         "forecast_tariff_group_8": ZonneplanSensorEntityDescription(
             key="forecast_tariff_group_8",
-            key_lambda=lambda: f"price_per_date_and_hour.{(datetime.now(UTC) + timedelta(hours=8)).strftime('%Y-%m-%d %H')}.tariff_group",
+            key_lambda=lambda: f"price_per_date_and_hour.{(datetime.now(ZONNEPLAN_API_TIME_ZONE) + timedelta(hours=8)).strftime('%Y-%m-%d %H')}.tariff_group",
             name="Forecast tariff group hour 8",
             translation_key="forecast_tariff_group_hour_8",
         ),

--- a/custom_components/zonneplan_one/coordinators/battery_charts_data_coordinator.py
+++ b/custom_components/zonneplan_one/coordinators/battery_charts_data_coordinator.py
@@ -10,7 +10,7 @@ from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.debounce import Debouncer
 
 from ..api import AsyncConfigEntryAuth
-from ..const import DOMAIN
+from ..const import DOMAIN, ZONNEPLAN_API_TIME_ZONE
 from ..zonneplan_api.types import ZonneplanContract
 from .zonneplan_data_update_coordinator import ZonneplanDataUpdateCoordinator
 
@@ -27,14 +27,13 @@ def _parse_day_chart(chart_data: Any, month_date: date) -> dict | None:
     meta = group.get("meta") or {}
 
     days: dict[str, Any] = {}
-    tz_ams = dt_util.get_time_zone("Europe/Amsterdam")
     for measurement in measurements:
         measured_at = measurement.get("measured_at")
         dt_value = dt_util.parse_datetime(measured_at) if measured_at else None
         if not dt_value:
             continue
 
-        dt_value = dt_util.as_utc(dt_value).astimezone(tz_ams)
+        dt_value = dt_util.as_utc(dt_value).astimezone(ZONNEPLAN_API_TIME_ZONE)
 
         day_key = dt_value.date().isoformat()
         days[day_key] = {
@@ -62,14 +61,13 @@ def _parse_month_chart(chart_data: Any, year: int) -> dict | None:
     meta = group.get("meta") or {}
 
     months: dict[str, Any] = {}
-    tz_ams = dt_util.get_time_zone("Europe/Amsterdam")
     for measurement in measurements:
         measured_at = measurement.get("measured_at")
         dt_value = dt_util.parse_datetime(measured_at) if measured_at else None
         if not dt_value:
             continue
 
-        dt_value = dt_util.as_utc(dt_value).astimezone(tz_ams)
+        dt_value = dt_util.as_utc(dt_value).astimezone(ZONNEPLAN_API_TIME_ZONE)
 
         month_key = dt_value.date().strftime("%Y-%m")
         months[month_key] = {

--- a/custom_components/zonneplan_one/coordinators/battery_control_data_coordinator.py
+++ b/custom_components/zonneplan_one/coordinators/battery_control_data_coordinator.py
@@ -55,9 +55,7 @@ class BatteryControlDataUpdateCoordinator(ZonneplanDataUpdateCoordinator):
             # instead of a 304, which would return None and leave the data empty.
             # Subsequent fetches use etags normally for efficiency.
             has_cached_battery_control = "battery_control_mode" in data
-            battery_control_mode = await self.api.async_get_battery_control_mode(
-                self.contract["uuid"], ignore_etag=not has_cached_battery_control
-            )
+            battery_control_mode = await self.api.async_get_battery_control_mode(self.contract["uuid"], ignore_etag=not has_cached_battery_control)
             if battery_control_mode:
                 data["battery_control_mode"] = battery_control_mode
 

--- a/custom_components/zonneplan_one/coordinators/electricity_data_coordinator.py
+++ b/custom_components/zonneplan_one/coordinators/electricity_data_coordinator.py
@@ -1,5 +1,4 @@
 import logging
-import zoneinfo
 from datetime import datetime, timedelta
 from http import HTTPStatus
 
@@ -25,7 +24,6 @@ class ElectricityDataUpdateCoordinator(ZonneplanDataUpdateCoordinator):
     address_uuid: str
     connection_uuid: str
     contracts: list[ZonneplanContract]
-    _zonneplan_api_time_zone: zoneinfo.ZoneInfo
     _statistics_service: ElectricityStatisticsService
 
     def __init__(

--- a/custom_components/zonneplan_one/coordinators/electricity_prices_data_coordinator.py
+++ b/custom_components/zonneplan_one/coordinators/electricity_prices_data_coordinator.py
@@ -28,7 +28,10 @@ def get_price_per_quarter_hour(data: dict) -> dict:
     price_by_quarter_hour = {}
     price_series = get_price_series_from_chart_data(data)
     for price_data in price_series:
+        dt = dt_util.parse_datetime(price_data["end_date"])
+        price_data["end_date"] = dt
         dt = dt_util.parse_datetime(price_data["start_date"])
+        price_data["start_date"] = dt
         quarter_dt = dt.replace(minute=(dt.minute // 15) * 15, second=0, microsecond=0).strftime("%Y-%m-%d %H:%M")
         price_by_quarter_hour[quarter_dt] = price_data
     return price_by_quarter_hour

--- a/custom_components/zonneplan_one/coordinators/electricity_prices_data_coordinator.py
+++ b/custom_components/zonneplan_one/coordinators/electricity_prices_data_coordinator.py
@@ -25,22 +25,11 @@ def get_price_per_hour_by_date(prices: list[dict]) -> dict:
 
 
 def get_price_per_quarter_hour(data: dict) -> dict:
-    zonneplan_api_time_zone = dt_util.get_time_zone("Europe/Amsterdam")
-
     price_by_quarter_hour = {}
     price_series = get_price_series_from_chart_data(data)
     for price_data in price_series:
-        if isinstance(price_data["end_date"], str):
-            dt_end = dt_util.parse_datetime(price_data["end_date"]).astimezone(zonneplan_api_time_zone)
-            price_data["end_date"] = dt_end
-
-        if isinstance(price_data["start_date"], str):
-            dt_start = dt_util.parse_datetime(price_data["start_date"]).astimezone(zonneplan_api_time_zone)
-            price_data["start_date"] = dt_start
-        else:
-            dt_start = price_data["start_date"]
-
-        quarter_dt = dt_start.replace(minute=(dt_start.minute // 15) * 15, second=0, microsecond=0).strftime("%Y-%m-%d %H:%M")
+        dt = price_data["start_date"]
+        quarter_dt = dt.replace(minute=(dt.minute // 15) * 15, second=0, microsecond=0).strftime("%Y-%m-%d %H:%M")
         price_by_quarter_hour[quarter_dt] = price_data
     return price_by_quarter_hour
 
@@ -51,8 +40,8 @@ def get_energy_price(data: dict, dt: datetime | None = None) -> int | None:
     price = None
     price_series = get_price_series_from_chart_data(data)
     for price_data in price_series:
-        start_datetime = dt_util.parse_datetime(price_data["start_date"])
-        end_datetime = dt_util.parse_datetime(price_data["end_date"])
+        start_datetime = price_data["start_date"]
+        end_datetime = price_data["end_date"]
         if start_datetime <= dt < end_datetime:
             price = price_data["price_tax_included"]["amount"]
             break
@@ -60,14 +49,28 @@ def get_energy_price(data: dict, dt: datetime | None = None) -> int | None:
 
 
 def get_price_series_from_chart_data(data: dict) -> list[dict]:
-    return data.get("chart", {}).get("series", {}).get("prices", [])
+    zonneplan_api_time_zone = dt_util.get_time_zone("Europe/Amsterdam")
+    prices = data.get("chart", {}).get("series", {}).get("prices", [])
+    date_fields = ["start_date", "end_date"]
+
+    return [
+        {
+            **price_data,
+            **{
+                field: dt_util.parse_datetime(price_data[field]).astimezone(zonneplan_api_time_zone)
+                for field in date_fields
+                if price_data.get(field)
+            },
+        }
+        for price_data in prices
+    ]
 
 
-def prepare_prices(data: dict) -> list[dict]:
+def prepare_legacy_prices(data: dict) -> list[dict]:
     prices = []
     price_series = get_price_series_from_chart_data(data)
     for price_data in price_series:
-        start_datetime = dt_util.parse_datetime(price_data["start_date"])
+        start_date = price_data["start_date"]
         price = price_data["price_tax_included"]["amount"]
         price_excl_tax = price_data["price_tax_excluded"]["amount"]
 
@@ -128,7 +131,7 @@ class ElectricityPricesDataUpdateCoordinator(ZonneplanDataUpdateCoordinator):
 
             if hourly:
                 price_data["hourly"] = hourly
-                legacy_hourly_electricity_prices = prepare_prices(hourly)
+                legacy_hourly_electricity_prices = prepare_legacy_prices(hourly)
                 price_data["legacy_price_per_hour"] = legacy_hourly_electricity_prices
                 price_data["price_per_date_and_hour"] = get_price_per_hour_by_date(legacy_hourly_electricity_prices)
                 price_data["price_per_hour"] = get_price_series_from_chart_data(hourly)

--- a/custom_components/zonneplan_one/coordinators/electricity_prices_data_coordinator.py
+++ b/custom_components/zonneplan_one/coordinators/electricity_prices_data_coordinator.py
@@ -20,7 +20,7 @@ _LOGGER = logging.getLogger(__name__)
 def get_price_per_hour_by_date(prices: list[dict]) -> dict:
     price_by_hour = {}
     for price_info in prices:
-        price_by_hour[price_info["datetime"].strftime("%Y-%m-%d %H")] = price_info
+        price_by_hour[price_info["start_date"].astimezone(UTC).strftime("%Y-%m-%d %H")] = price_info
     return price_by_hour
 
 
@@ -75,7 +75,8 @@ def prepare_legacy_prices(data: dict) -> list[dict]:
         price_excl_tax = price_data["price_tax_excluded"]["amount"]
 
         price_info = {
-            "datetime": start_datetime,
+            "start_date": start_date,
+            "datetime": start_date.astimezone(UTC).isoformat(),
             "electricity_price": price,
             "electricity_price_excl_tax": price_excl_tax,
         }

--- a/custom_components/zonneplan_one/coordinators/electricity_prices_data_coordinator.py
+++ b/custom_components/zonneplan_one/coordinators/electricity_prices_data_coordinator.py
@@ -29,16 +29,16 @@ def get_price_per_quarter_hour(data: dict) -> dict:
     price_series = get_price_series_from_chart_data(data)
     for price_data in price_series:
         if isinstance(price_data["end_date"], str):
-            dtEnd = dt_util.parse_datetime(price_data["end_date"])
-            price_data["end_date"] = dtEnd
+            dt_end = dt_util.parse_datetime(price_data["end_date"])
+            price_data["end_date"] = dt_end
 
         if isinstance(price_data["start_date"], str):
-            dtStart = dt_util.parse_datetime(price_data["start_date"])
-            price_data["start_date"] = dtStart
+            dt_start = dt_util.parse_datetime(price_data["start_date"])
+            price_data["start_date"] = dt_start
         else:
-            dtStart = price_data["start_date"]
+            dt_start = price_data["start_date"]
 
-        quarter_dt = dtStart.replace(minute=(dtStart.minute // 15) * 15, second=0, microsecond=0).strftime("%Y-%m-%d %H:%M")
+        quarter_dt = dt_start.replace(minute=(dt_start.minute // 15) * 15, second=0, microsecond=0).strftime("%Y-%m-%d %H:%M")
         price_by_quarter_hour[quarter_dt] = price_data
     return price_by_quarter_hour
 

--- a/custom_components/zonneplan_one/coordinators/electricity_prices_data_coordinator.py
+++ b/custom_components/zonneplan_one/coordinators/electricity_prices_data_coordinator.py
@@ -28,11 +28,17 @@ def get_price_per_quarter_hour(data: dict) -> dict:
     price_by_quarter_hour = {}
     price_series = get_price_series_from_chart_data(data)
     for price_data in price_series:
-        dt = dt_util.parse_datetime(price_data["end_date"])
-        price_data["end_date"] = dt
-        dt = dt_util.parse_datetime(price_data["start_date"])
-        price_data["start_date"] = dt
-        quarter_dt = dt.replace(minute=(dt.minute // 15) * 15, second=0, microsecond=0).strftime("%Y-%m-%d %H:%M")
+        if isinstance(price_data["end_date"], str):
+            dtEnd = dt_util.parse_datetime(price_data["end_date"])
+            price_data["end_date"] = dtEnd
+
+        if isinstance(price_data["start_date"], str):
+            dtStart = dt_util.parse_datetime(price_data["start_date"])
+            price_data["start_date"] = dtStart
+        else:
+            dtStart = price_data["start_date"]
+
+        quarter_dt = dtStart.replace(minute=(dtStart.minute // 15) * 15, second=0, microsecond=0).strftime("%Y-%m-%d %H:%M")
         price_by_quarter_hour[quarter_dt] = price_data
     return price_by_quarter_hour
 

--- a/custom_components/zonneplan_one/coordinators/electricity_prices_data_coordinator.py
+++ b/custom_components/zonneplan_one/coordinators/electricity_prices_data_coordinator.py
@@ -10,7 +10,7 @@ from homeassistant.helpers.debounce import Debouncer
 from homeassistant.helpers.event import async_track_point_in_utc_time
 
 from ..api import AsyncConfigEntryAuth
-from ..const import DOMAIN
+from ..const import DOMAIN, ZONNEPLAN_API_TIME_ZONE
 from ..zonneplan_api.types import ZonneplanContract
 from .zonneplan_data_update_coordinator import ZonneplanDataUpdateCoordinator
 
@@ -20,7 +20,7 @@ _LOGGER = logging.getLogger(__name__)
 def get_price_per_hour_by_date(prices: list[dict]) -> dict:
     price_by_hour = {}
     for price_info in prices:
-        price_by_hour[price_info["start_date"].astimezone(UTC).strftime("%Y-%m-%d %H")] = price_info
+        price_by_hour[price_info["start_date"].strftime("%Y-%m-%d %H")] = price_info
     return price_by_hour
 
 
@@ -49,18 +49,13 @@ def get_energy_price(data: dict, dt: datetime | None = None) -> int | None:
 
 
 def get_price_series_from_chart_data(data: dict) -> list[dict]:
-    zonneplan_api_time_zone = dt_util.get_time_zone("Europe/Amsterdam")
     prices = data.get("chart", {}).get("series", {}).get("prices", [])
     date_fields = ["start_date", "end_date"]
 
     return [
         {
             **price_data,
-            **{
-                field: dt_util.parse_datetime(price_data[field]).astimezone(zonneplan_api_time_zone)
-                for field in date_fields
-                if price_data.get(field)
-            },
+            **{field: dt_util.parse_datetime(price_data[field]).astimezone(ZONNEPLAN_API_TIME_ZONE) for field in date_fields if price_data.get(field)},
         }
         for price_data in prices
     ]

--- a/custom_components/zonneplan_one/coordinators/electricity_prices_data_coordinator.py
+++ b/custom_components/zonneplan_one/coordinators/electricity_prices_data_coordinator.py
@@ -25,15 +25,17 @@ def get_price_per_hour_by_date(prices: list[dict]) -> dict:
 
 
 def get_price_per_quarter_hour(data: dict) -> dict:
+    zonneplan_api_time_zone = dt_util.get_time_zone("Europe/Amsterdam")
+
     price_by_quarter_hour = {}
     price_series = get_price_series_from_chart_data(data)
     for price_data in price_series:
         if isinstance(price_data["end_date"], str):
-            dt_end = dt_util.parse_datetime(price_data["end_date"])
+            dt_end = dt_util.parse_datetime(price_data["end_date"]).astimezone(zonneplan_api_time_zone)
             price_data["end_date"] = dt_end
 
         if isinstance(price_data["start_date"], str):
-            dt_start = dt_util.parse_datetime(price_data["start_date"])
+            dt_start = dt_util.parse_datetime(price_data["start_date"]).astimezone(zonneplan_api_time_zone)
             price_data["start_date"] = dt_start
         else:
             dt_start = price_data["start_date"]

--- a/custom_components/zonneplan_one/coordinators/gas_prices_data_coordinator.py
+++ b/custom_components/zonneplan_one/coordinators/gas_prices_data_coordinator.py
@@ -1,5 +1,5 @@
 import logging
-from datetime import UTC, datetime, timedelta
+from datetime import datetime, timedelta
 from http import HTTPStatus
 
 import homeassistant.util.dt as dt_util
@@ -10,7 +10,7 @@ from homeassistant.helpers.debounce import Debouncer
 from homeassistant.helpers.event import async_track_point_in_utc_time
 
 from ..api import AsyncConfigEntryAuth
-from ..const import DOMAIN
+from ..const import DOMAIN, ZONNEPLAN_API_TIME_ZONE
 from ..zonneplan_api.types import ZonneplanContract
 from .zonneplan_data_update_coordinator import ZonneplanDataUpdateCoordinator
 
@@ -22,23 +22,18 @@ def get_prices_by_date_and_hour(prices: list[dict]) -> dict:
     for price_data in prices:
         start_datetime = price_data["start_date"]
         if start_datetime:
-            price_by_hour[start_datetime.astimezone(UTC).strftime("%Y-%m-%d %H")] = price_data
+            price_by_hour[start_datetime.strftime("%Y-%m-%d %H")] = price_data
     return price_by_hour
 
 
 def get_price_series_from_chart_data(data: dict) -> list[dict]:
-    zonneplan_api_time_zone = dt_util.get_time_zone("Europe/Amsterdam")
     prices = data.get("chart", {}).get("series", {}).get("prices", [])
     date_fields = ["start_date", "end_date"]
 
     return [
         {
             **price_data,
-            **{
-                field: dt_util.parse_datetime(price_data[field]).astimezone(zonneplan_api_time_zone)
-                for field in date_fields
-                if price_data.get(field)
-            },
+            **{field: dt_util.parse_datetime(price_data[field]).astimezone(ZONNEPLAN_API_TIME_ZONE) for field in date_fields if price_data.get(field)},
         }
         for price_data in prices
     ]

--- a/custom_components/zonneplan_one/coordinators/gas_prices_data_coordinator.py
+++ b/custom_components/zonneplan_one/coordinators/gas_prices_data_coordinator.py
@@ -22,7 +22,16 @@ def get_prices_by_date_and_hour(prices: dict) -> dict:
 
     price_by_hour = {}
     for price_data in get_price_series_from_chart_data(prices):
-        start_datetime = dt_util.parse_datetime(price_data["start_date"]).astimezone(zonneplan_api_time_zone)
+        if isinstance(price_data["start_date"], str):
+            start_datetime = dt_util.parse_datetime(price_data["start_date"]).astimezone(zonneplan_api_time_zone)
+            price_data["start_date"] = start_datetime
+        else:
+            start_datetime = price_data["start_date"]
+
+        if isinstance(price_data["end_date"], str):
+            end_datetime = dt_util.parse_datetime(price_data["end_date"]).astimezone(zonneplan_api_time_zone)
+            price_data["end_date"] = end_datetime
+
         if start_datetime:
             price_by_hour[start_datetime.strftime("%Y-%m-%d %H")] = price_data
     return price_by_hour

--- a/custom_components/zonneplan_one/coordinators/gas_prices_data_coordinator.py
+++ b/custom_components/zonneplan_one/coordinators/gas_prices_data_coordinator.py
@@ -1,5 +1,5 @@
 import logging
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from http import HTTPStatus
 
 import homeassistant.util.dt as dt_util
@@ -17,28 +17,31 @@ from .zonneplan_data_update_coordinator import ZonneplanDataUpdateCoordinator
 _LOGGER = logging.getLogger(__name__)
 
 
-def get_prices_by_date_and_hour(prices: dict) -> dict:
-    zonneplan_api_time_zone = dt_util.get_time_zone("Europe/Amsterdam")
-
+def get_prices_by_date_and_hour(prices: list[dict]) -> dict:
     price_by_hour = {}
-    for price_data in get_price_series_from_chart_data(prices):
-        if isinstance(price_data["start_date"], str):
-            start_datetime = dt_util.parse_datetime(price_data["start_date"]).astimezone(zonneplan_api_time_zone)
-            price_data["start_date"] = start_datetime
-        else:
-            start_datetime = price_data["start_date"]
-
-        if isinstance(price_data["end_date"], str):
-            end_datetime = dt_util.parse_datetime(price_data["end_date"]).astimezone(zonneplan_api_time_zone)
-            price_data["end_date"] = end_datetime
-
+    for price_data in prices:
+        start_datetime = price_data["start_date"]
         if start_datetime:
-            price_by_hour[start_datetime.strftime("%Y-%m-%d %H")] = price_data
+            price_by_hour[start_datetime.astimezone(UTC).strftime("%Y-%m-%d %H")] = price_data
     return price_by_hour
 
 
 def get_price_series_from_chart_data(data: dict) -> list[dict]:
-    return data.get("chart", {}).get("series", {}).get("prices", [])
+    zonneplan_api_time_zone = dt_util.get_time_zone("Europe/Amsterdam")
+    prices = data.get("chart", {}).get("series", {}).get("prices", [])
+    date_fields = ["start_date", "end_date"]
+
+    return [
+        {
+            **price_data,
+            **{
+                field: dt_util.parse_datetime(price_data[field]).astimezone(zonneplan_api_time_zone)
+                for field in date_fields
+                if price_data.get(field)
+            },
+        }
+        for price_data in prices
+    ]
 
 
 class GasPricesDataUpdateCoordinator(ZonneplanDataUpdateCoordinator):
@@ -79,8 +82,9 @@ class GasPricesDataUpdateCoordinator(ZonneplanDataUpdateCoordinator):
             data = {}
             gas_daily = await self.api.async_get_consumer_prices("gas-daily")
             if gas_daily:
-                data["gas_prices"] = get_prices_by_date_and_hour(gas_daily)
-                data["forecast"] = get_price_series_from_chart_data(gas_daily)
+                prices = get_price_series_from_chart_data(gas_daily)
+                data["gas_prices"] = get_prices_by_date_and_hour(prices)
+                data["forecast"] = prices
 
                 if not self._unsub_hour_update:
                     self._schedule_hourly_listener_update()

--- a/custom_components/zonneplan_one/coordinators/statistics.py
+++ b/custom_components/zonneplan_one/coordinators/statistics.py
@@ -2,7 +2,7 @@ import asyncio
 import logging
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
-from datetime import datetime, time, timedelta, tzinfo
+from datetime import datetime, time, timedelta
 from typing import Any
 
 import homeassistant.util.dt as dt_util
@@ -25,7 +25,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.util.unit_conversion import EnergyConverter, VolumeConverter
 
 from ..api import AsyncConfigEntryAuth, ZonneplanApiError, ZonneplanRateLimitError
-from ..const import DOMAIN
+from ..const import DOMAIN, ZONNEPLAN_API_TIME_ZONE
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -61,7 +61,6 @@ class BaseZonneplanStatisticsService(ABC):
     """Base class for statistics services, providing common utilities."""
 
     hass: HomeAssistant
-    zonneplan_api_time_zone: tzinfo
     channel_configs: tuple[StatisticChannelConfig, ...]
 
     def __init__(
@@ -69,7 +68,6 @@ class BaseZonneplanStatisticsService(ABC):
         hass: HomeAssistant,
     ) -> None:
         self.hass = hass
-        self.zonneplan_api_time_zone = dt_util.get_time_zone("Europe/Amsterdam")
         self._refetched_statistics_yesterday: datetime | None = None
 
     @abstractmethod
@@ -86,7 +84,7 @@ class BaseZonneplanStatisticsService(ABC):
             return
 
         states = await self._load_current_states()
-        start_of_today = dt_util.now(self.zonneplan_api_time_zone).replace(hour=0, minute=0, second=0, microsecond=0)
+        start_of_today = dt_util.now(ZONNEPLAN_API_TIME_ZONE).replace(hour=0, minute=0, second=0, microsecond=0)
         backfill_failed = False
         if any(state.last_time < start_of_today for state in states.values()):
             try:
@@ -111,7 +109,7 @@ class BaseZonneplanStatisticsService(ABC):
 
     async def _refetch_and_process_yesterday(self, data_today: dict[str, Any]) -> bool:
         """Refetch yesterday once per day when the configured cutoff has passed."""
-        zonneplan_now = dt_util.now(self.zonneplan_api_time_zone)
+        zonneplan_now = dt_util.now(ZONNEPLAN_API_TIME_ZONE)
         start_of_today = zonneplan_now.replace(hour=0, minute=0, second=0, microsecond=0)
         cutoff_time = self.refetch_yesterday_cutoff_time()
         if zonneplan_now.time() < cutoff_time:
@@ -120,9 +118,7 @@ class BaseZonneplanStatisticsService(ABC):
         if self._refetched_statistics_yesterday and self._refetched_statistics_yesterday >= start_of_today:
             return False
 
-        _LOGGER.info(
-            "Refetching yesterday's for %s statistics to ensure data is up to date", [config.key for config in self.channel_configs]
-        )
+        _LOGGER.info("Refetching yesterday's for %s statistics to ensure data is up to date", [config.key for config in self.channel_configs])
         try:
             if await self._refetch_yesterday(start_of_today - timedelta(days=1), data_today):
                 self._refetched_statistics_yesterday = start_of_today
@@ -182,9 +178,9 @@ class BaseZonneplanStatisticsService(ABC):
 
             baseline_start = baseline.get("start")
             last_time = (
-                datetime.fromtimestamp(baseline_start, tz=dt_util.UTC).astimezone(self.zonneplan_api_time_zone)
+                datetime.fromtimestamp(baseline_start, tz=dt_util.UTC).astimezone(ZONNEPLAN_API_TIME_ZONE)
                 if baseline_start is not None
-                else start_of_day.astimezone(self.zonneplan_api_time_zone)
+                else start_of_day.astimezone(ZONNEPLAN_API_TIME_ZONE)
             )
             states[config.key] = StatisticChannelState(
                 config=config,
@@ -197,7 +193,7 @@ class BaseZonneplanStatisticsService(ABC):
             "Last state to work with: %s",
             {
                 key: {
-                    "last_time": state.last_time.astimezone(self.zonneplan_api_time_zone).strftime("%Y-%m-%d %H:%M"),
+                    "last_time": state.last_time.astimezone(ZONNEPLAN_API_TIME_ZONE).strftime("%Y-%m-%d %H:%M"),
                     "sum": state.total_sum,
                     "last_state": state.last_state_value,
                 }
@@ -213,7 +209,7 @@ class BaseZonneplanStatisticsService(ABC):
         for config in self.channel_configs:
             last_stat = await self._get_last_statistic(config.statistic_id)
             if last_stat:
-                last_time = datetime.fromtimestamp(last_stat["start"], tz=dt_util.UTC).astimezone(self.zonneplan_api_time_zone)
+                last_time = datetime.fromtimestamp(last_stat["start"], tz=dt_util.UTC).astimezone(ZONNEPLAN_API_TIME_ZONE)
                 total_sum = float(last_stat.get("sum", 0.0))
                 last_state_value = float(last_stat.get("state", 0.0))
                 _LOGGER.debug("Last stat for %s (%s): %s", config.statistic_id, last_time, last_stat)
@@ -233,8 +229,8 @@ class BaseZonneplanStatisticsService(ABC):
 
     def _fallback_last_stats_datetime(self) -> datetime:
         """Fallback datetime for last statistic to 1ste of the month."""
-        now = dt_util.now(self.zonneplan_api_time_zone)
-        return datetime(now.year, now.month, 1, tzinfo=self.zonneplan_api_time_zone)
+        now = dt_util.now(ZONNEPLAN_API_TIME_ZONE)
+        return datetime(now.year, now.month, 1, tzinfo=ZONNEPLAN_API_TIME_ZONE)
 
     async def _backfill_history(
         self,
@@ -328,12 +324,12 @@ class BaseZonneplanStatisticsService(ABC):
         for entry in measurements:
             for config in self.channel_configs:
                 entry_time = dt_util.parse_datetime(entry.get(config.date_key)).replace(minute=0, second=0, microsecond=0)
-                if (last_entry_time and entry_time < last_entry_time) or entry_time > datetime.now(tz=self.zonneplan_api_time_zone):
+                if (last_entry_time and entry_time < last_entry_time) or entry_time > datetime.now(tz=ZONNEPLAN_API_TIME_ZONE):
                     _LOGGER.debug(
                         "Skipping %s entry for %s last_entry_time=%s => %s",
                         config.key,
-                        entry_time.astimezone(self.zonneplan_api_time_zone).strftime("%Y-%m-%d %H:%M"),
-                        last_entry_time.astimezone(self.zonneplan_api_time_zone).strftime("%Y-%m-%d %H:%M") if last_entry_time else "None",
+                        entry_time.astimezone(ZONNEPLAN_API_TIME_ZONE).strftime("%Y-%m-%d %H:%M"),
+                        last_entry_time.astimezone(ZONNEPLAN_API_TIME_ZONE).strftime("%Y-%m-%d %H:%M") if last_entry_time else "None",
                         entry,
                     )
                     continue
@@ -386,7 +382,7 @@ class BaseZonneplanStatisticsService(ABC):
             "Finished processing stats: %s",
             {
                 key: {
-                    "last_time": state.last_time.astimezone(self.zonneplan_api_time_zone).strftime("%Y-%m-%d %H:%M"),
+                    "last_time": state.last_time.astimezone(ZONNEPLAN_API_TIME_ZONE).strftime("%Y-%m-%d %H:%M"),
                     "sum": state.total_sum,
                     "last_state": state.last_state_value,
                 }
@@ -415,8 +411,8 @@ class BaseZonneplanStatisticsService(ABC):
         then re-fetches and re-ingests all hourly data from start_date until now.
         """
         # Normalize to midnight of the requested date in the API timezone
-        start_of_day = start_date.astimezone(self.zonneplan_api_time_zone).replace(hour=0, minute=0, second=0, microsecond=0)
-        start_of_today = dt_util.now(self.zonneplan_api_time_zone).replace(hour=0, minute=0, second=0, microsecond=0)
+        start_of_day = start_date.astimezone(ZONNEPLAN_API_TIME_ZONE).replace(hour=0, minute=0, second=0, microsecond=0)
+        start_of_today = dt_util.now(ZONNEPLAN_API_TIME_ZONE).replace(hour=0, minute=0, second=0, microsecond=0)
 
         notification_id = ",".join([config.statistic_id for config in self.channel_configs])
         msg = f"Starting manual backfill for {notification_id} from {start_of_day} to {start_of_today}"
@@ -477,7 +473,7 @@ class BaseZonneplanStatisticsService(ABC):
         persistent_notification.create(self.hass, msg, "Statistics backfill complete", notification_id)
 
     def _zonneplan_api_date_param(self, day: datetime) -> str:
-        return day.astimezone(self.zonneplan_api_time_zone).strftime("%Y-%m-%d")
+        return day.astimezone(ZONNEPLAN_API_TIME_ZONE).strftime("%Y-%m-%d")
 
 
 class ElectricityStatisticsService(BaseZonneplanStatisticsService):
@@ -522,9 +518,7 @@ class ElectricityStatisticsService(BaseZonneplanStatisticsService):
 
     async def _fetch_day_payload(self, day: datetime, *, ignore_etag: bool = False) -> dict[str, Any] | None:
         date_str = self._zonneplan_api_date_param(day)
-        day_payload = await self.api.async_get(
-            self.connection_uuid, f"/electricity-delivered/charts/hours?date={date_str}", ignore_etag=ignore_etag
-        )
+        day_payload = await self.api.async_get(self.connection_uuid, f"/electricity-delivered/charts/hours?date={date_str}", ignore_etag=ignore_etag)
         _LOGGER.debug("Fetched Electricity day payload for %s: has_data=%s", date_str, bool(day_payload))
         return day_payload
 

--- a/custom_components/zonneplan_one/entity.py
+++ b/custom_components/zonneplan_one/entity.py
@@ -132,12 +132,8 @@ class PvEntity:
                 + "Wp"
             )
             device_info["serial_number"] = self.coordinator.contracts[self._install_index]["meta"].get("sgn_serial_number", "")
-            device_info["sw_version"] = (
-                self.coordinator.contracts[self._install_index]["meta"].get("module_firmware_version", "") or "unknown"
-            )
-            device_info["hw_version"] = (
-                self.coordinator.contracts[self._install_index]["meta"].get("inverter_firmware_version", "") or "unknown"
-            )
+            device_info["sw_version"] = self.coordinator.contracts[self._install_index]["meta"].get("module_firmware_version", "") or "unknown"
+            device_info["hw_version"] = self.coordinator.contracts[self._install_index]["meta"].get("inverter_firmware_version", "") or "unknown"
 
         return device_info
 

--- a/custom_components/zonneplan_one/sensor.py
+++ b/custom_components/zonneplan_one/sensor.py
@@ -19,7 +19,6 @@ from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.update_coordinator import (
     CoordinatorEntity,
 )
-from pytz import timezone
 
 from .const import (
     BATTERY,
@@ -37,6 +36,7 @@ from .const import (
     P1_GAS,
     PV_INSTALL,
     SENSOR_TYPES,
+    ZONNEPLAN_API_TIME_ZONE,
     ZonneplanSensorEntityDescription,
 )
 from .coordinators.account_data_coordinator import (
@@ -207,9 +207,7 @@ async def add_electricity_sensors(
     _migrate_to_new_unique_id(hass, f"{uuid}_current_electricity_tariff", f"{uuid}_current_tariff")
 
 
-async def add_gas_sensors(
-    entities: list[Any], connection: ConnectionCoordinators, uuid: str, hass: HomeAssistant, other_connection_uuids: list[str]
-) -> None:
+async def add_gas_sensors(entities: list[Any], connection: ConnectionCoordinators, uuid: str, hass: HomeAssistant, other_connection_uuids: list[str]) -> None:
     if not connection.gas_prices:
         return
 
@@ -440,9 +438,9 @@ class ZonneplanSensor(CoordinatorEntity, RestoreSensor, ABC):
                 if isinstance(value, str):
                     value = dt_util.parse_datetime(value)
                 elif value > 100000000000000:  # noqa: PLR2004
-                    value = datetime.fromtimestamp(value / 1000000, timezone("Europe/Amsterdam"))
+                    value = datetime.fromtimestamp(value / 1000000, ZONNEPLAN_API_TIME_ZONE)
                 else:
-                    value = datetime.fromtimestamp(value / 1000, timezone("Europe/Amsterdam"))
+                    value = datetime.fromtimestamp(value / 1000, ZONNEPLAN_API_TIME_ZONE)
 
             if self.entity_description.value_factor:
                 value = value * self.entity_description.value_factor

--- a/custom_components/zonneplan_one/services.py
+++ b/custom_components/zonneplan_one/services.py
@@ -3,7 +3,6 @@
 import logging
 from datetime import datetime
 
-import homeassistant.util.dt as dt_util
 import voluptuous as vol
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import (
@@ -19,6 +18,7 @@ from .const import (
     DOMAIN,
     ELECTRICITY,
     GAS,
+    ZONNEPLAN_API_TIME_ZONE,
 )
 
 SERVICE_FETCH_STATISTICS = "fetch_statistics"
@@ -50,11 +50,10 @@ def async_setup_fetch_statistics_service(hass: HomeAssistant) -> None:
         start_date_str: str = call.data[_ATTR_START_DATE]
         connection_uuid_filter: str | None = call.data.get(_ATTR_CONNECTION_UUID)
 
-        amsterdam_tz = dt_util.get_time_zone("Europe/Amsterdam")
         start_date: datetime | None = None
         for fmt in _DATE_FORMATS:
             try:
-                start_date = datetime.strptime(start_date_str, fmt).replace(tzinfo=amsterdam_tz)
+                start_date = datetime.strptime(start_date_str, fmt).replace(tzinfo=ZONNEPLAN_API_TIME_ZONE)
                 break
             except ValueError:
                 continue


### PR DESCRIPTION
The ``start_date`` and ``end_date`` entries in the quartely hour price data is in the form of a string. This makes it hard(er) to select the correct time period.

This PR parses both date fields and stores them back into the data for easier selection.