### PR TITLE
Stage charge planning edits behind an apply button

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,42 @@ _Sensors available if you have a Zonneplan charge point/laadpaal_
 - Charge point dynamic charging flex suppressed `on/off` _(default disabled)_
 - Charge on solar enabled `on/off`
 - Buttons to start/stop charge
+- Charge planning: departure time, desired distance, desired percentage, selected car and the apply/cancel/delete buttons
+
+#### Planning a charge session
+
+The planning controls are grouped under **Configuration** on the device page, separate from the
+start/stop buttons. Changing one of them does not contact Zonneplan: the new value is kept locally
+until you press **Apply changes**, which sends the whole planning in a single call. **Cancel
+changes** throws the local changes away and puts the fields back to what Zonneplan currently has.
+Both buttons are only available while there is something to apply or cancel, and applying
+additionally needs a complete planning: a departure time at least 15 minutes out and either a
+distance or a percentage. **Delete planning** clears the planning at Zonneplan altogether and is
+available whenever a planning exists, whether or not you have staged any changes.
+
+A session can be planned by distance or by percentage, but not both, so filling in one greys out
+the other until you apply or cancel the changes.
+
+Fields you have not changed keep following Zonneplan: when a planned session expires the fields
+empty themselves, and when you change the planning in the Zonneplan app the fields update along
+with it.
+
+The device page sorts entities alphabetically and always renders the Configuration block below the
+sensors, so add them to a dashboard to get them where and in the order you want (replace
+`<charge_point>` with your own entity id prefix):
+
+```yaml
+type: entities
+title: Charge planning
+entities:
+  - select.<charge_point>_charge_point_vehicle
+  - datetime.<charge_point>_charge_point_dynamic_load_desired_end_time
+  - number.<charge_point>_desired_kilometers
+  - number.<charge_point>_desired_percentage
+  - button.<charge_point>_apply_changes
+  - button.<charge_point>_cancel_changes
+  - button.<charge_point>_delete_planning
+```
 
 ### Zonneplan Battery
 _Sensors available if you have a Zonneplan Nexus battery_

--- a/custom_components/zonneplan_one/button.py
+++ b/custom_components/zonneplan_one/button.py
@@ -86,16 +86,20 @@ class ZonneplanChargePointButton(ChargePointEntity, CoordinatorEntity, ButtonEnt
 
         state = self.coordinator.get_data_value("state")
 
-        if not state or not state["connectivity_state"]:
+        if not state or not state["connectivity_state"] or "processing" in state:
             return False
 
-        if "processing" in state:
-            return False
+        available = {
+            "start": lambda: state["state"] == "VehicleDetected",
+            "stop": lambda: state["state"] == "Charging",
+            "apply_dynamic_charge": lambda: (
+                self.coordinator.has_pending_dynamic_charge_changes() and self.coordinator.dynamic_charge_params_are_valid()
+            ),
+            "discard_dynamic_charge": self.coordinator.has_pending_dynamic_charge_changes,
+            "reset_dynamic_charge": self.coordinator.has_dynamic_charge_schedule,
+        }.get(self._button_key)
 
-        if self._button_key == "stop" and state["state"] == "Charging":
-            return True
-
-        return bool(self._button_key == "start" and state["state"] == "VehicleDetected")
+        return bool(available and available())
 
     async def async_press(self) -> None:
         """Handle the button press."""
@@ -103,5 +107,11 @@ class ZonneplanChargePointButton(ChargePointEntity, CoordinatorEntity, ButtonEnt
             await self.coordinator.async_start_charge()
         elif self._button_key == "stop":
             await self.coordinator.async_stop_charge()
+        elif self._button_key == "apply_dynamic_charge":
+            await self.coordinator.async_apply_dynamic_charge()
+        elif self._button_key == "discard_dynamic_charge":
+            self.coordinator.discard_dynamic_charge_changes()
+        elif self._button_key == "reset_dynamic_charge":
+            await self.coordinator.async_reset_dynamic_charge()
         else:
             _LOGGER.warning("Unknown button action for %s", self._button_key)

--- a/custom_components/zonneplan_one/const.py
+++ b/custom_components/zonneplan_one/const.py
@@ -23,6 +23,7 @@ from homeassistant.components.sensor import (
 )
 from homeassistant.const import (
     CURRENCY_EURO,
+    EntityCategory,
     UnitOfEnergy,
     UnitOfLength,
     UnitOfPower,
@@ -1065,7 +1066,7 @@ SENSOR_TYPES: dict[
         "backup_power_usable_capacity_wh": ZonneplanSensorEntityDescription(
             key="contracts.{install_index}.meta.backup_power_usable_capacity_wh",
             name="Backup power usable capacity",
-            translation_key="battery_cycles",
+            translation_key="backup_power_usable_capacity_wh",
             native_unit_of_measurement=UnitOfEnergy.WATT_HOUR,
             device_class=SensorDeviceClass.ENERGY,
         ),
@@ -1635,6 +1636,27 @@ BUTTON_TYPES: dict[str, dict[str, ZonneplanButtonEntityDescription]] = {
             name="Stop charge",
             translation_key="stop_charge",
         ),
+        "apply_dynamic_charge": ZonneplanButtonEntityDescription(
+            key="charge_point.apply_dynamic_charge",
+            name="Apply changes",
+            translation_key="apply_dynamic_charge",
+            icon="mdi:calendar-check",
+            entity_category=EntityCategory.CONFIG,
+        ),
+        "discard_dynamic_charge": ZonneplanButtonEntityDescription(
+            key="charge_point.discard_dynamic_charge",
+            name="Cancel changes",
+            translation_key="discard_dynamic_charge",
+            icon="mdi:calendar-remove",
+            entity_category=EntityCategory.CONFIG,
+        ),
+        "reset_dynamic_charge": ZonneplanButtonEntityDescription(
+            key="charge_point.reset_dynamic_charge",
+            name="Delete planning",
+            translation_key="reset_dynamic_charge",
+            icon="mdi:calendar-remove-outline",
+            entity_category=EntityCategory.CONFIG,
+        ),
     },
 }
 
@@ -1679,6 +1701,7 @@ NUMBER_TYPES: dict[str, dict[str, ZonneplanNumberEntityDescription]] = {
             native_max_value=100,
             native_min_value=5,
             value_factor=0.1,
+            entity_category=EntityCategory.CONFIG,
         ),
         "dynamic_charging_user_constraints.desired_distance_in_kilometers": ZonneplanNumberEntityDescription(
             key="state.dynamic_charging_user_constraints.desired_distance_in_kilometers",
@@ -1688,6 +1711,7 @@ NUMBER_TYPES: dict[str, dict[str, ZonneplanNumberEntityDescription]] = {
             native_unit_of_measurement=UnitOfLength.KILOMETERS,
             entity_registry_enabled_default=True,
             native_max_value=500,  # will be updated later to match the vehicle
+            entity_category=EntityCategory.CONFIG,
         ),
     },
 }
@@ -1707,6 +1731,7 @@ SELECT_TYPES = {
             name="Charge point vehicle",
             translation_key="charge_point_vehicle",
             icon="mdi:car-electric",
+            entity_category=EntityCategory.CONFIG,
         )
     },
 }
@@ -1718,6 +1743,7 @@ DATETIME_TYPE = {
             name="Charge point dynamic load desired end time",
             translation_key="charge_point_dynamic_load_desired_end_time",
             entity_registry_enabled_default=True,
+            entity_category=EntityCategory.CONFIG,
         ),
     }
 }

--- a/custom_components/zonneplan_one/coordinators/charge_point_data_coordinator.py
+++ b/custom_components/zonneplan_one/coordinators/charge_point_data_coordinator.py
@@ -1,5 +1,5 @@
 import logging
-from datetime import timedelta
+from datetime import datetime, timedelta
 from http import HTTPStatus
 from typing import TYPE_CHECKING, Any
 
@@ -10,7 +10,7 @@ from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.debounce import Debouncer
 from homeassistant.helpers.event import async_call_later
 
-from ..api import AsyncConfigEntryAuth
+from ..api import AsyncConfigEntryAuth, ZonneplanRateLimitError
 from ..const import DOMAIN
 from ..zonneplan_api.types import ZonneplanContract
 from .zonneplan_data_update_coordinator import ZonneplanDataUpdateCoordinator
@@ -19,6 +19,19 @@ if TYPE_CHECKING:
     from collections.abc import Callable
 
 _LOGGER = logging.getLogger(__name__)
+
+DYNAMIC_CHARGE_CONSTRAINTS = "state.dynamic_charging_user_constraints"
+DYNAMIC_CHARGE_END_TIME = DYNAMIC_CHARGE_CONSTRAINTS + ".desired_end_time"
+DYNAMIC_CHARGE_PERCENTAGE = DYNAMIC_CHARGE_CONSTRAINTS + ".desired_additional_battery_percentage"
+DYNAMIC_CHARGE_KILOMETERS = DYNAMIC_CHARGE_CONSTRAINTS + ".desired_distance_in_kilometers"
+
+DYNAMIC_CHARGE_AMOUNT_UNITS = {
+    DYNAMIC_CHARGE_KILOMETERS: "kilometers",
+    DYNAMIC_CHARGE_PERCENTAGE: "percentage",
+}
+
+# The API rejects a session that ends (nearly) immediately.
+MIN_DYNAMIC_CHARGE_DURATION = timedelta(minutes=15)
 
 
 class ChargePointDataUpdateCoordinator(ZonneplanDataUpdateCoordinator):
@@ -53,7 +66,8 @@ class ChargePointDataUpdateCoordinator(ZonneplanDataUpdateCoordinator):
         self.contract = contract
 
         self._delayed_fetch_charge_point: Callable[[], None] | None = None
-        self._last_edited_dynamic_charge_unit: str | None = None
+        self._pending_dynamic_charge: dict[str, Any] = {}
+        self._pending_dynamic_charge_baseline: dict[str, Any] = {}
         self.vehicles: list[dict] = []
         self.selected_vehicle_uuid: str | None = None
         self.zonneplan_api_time_zone = dt_util.get_time_zone("Europe/Amsterdam")
@@ -62,17 +76,19 @@ class ChargePointDataUpdateCoordinator(ZonneplanDataUpdateCoordinator):
         """Fetch the latest status."""
         try:
             charge_point = await self._async_get_charge_point_data(self.connection_uuid, self.contract.get("uuid"))
-
-            if not charge_point:
-                return self.data
-
-            self.vehicles = charge_point.get("vehicles") or []
-            return charge_point["contracts"][0]
-
         except ClientResponseError as e:
             if e.status == HTTPStatus.UNAUTHORIZED:
                 raise ConfigEntryAuthFailed from e
             raise
+
+        if not charge_point:
+            return self.data
+
+        contract = charge_point["contracts"][0]
+        self.vehicles = charge_point.get("vehicles") or []
+        self._reconcile_pending_dynamic_charge(contract)
+
+        return contract
 
     async def _async_get_charge_point_data(self, connection_uuid: str, charge_point_uuid: str) -> dict:
         return await self.api.async_get(connection_uuid, "/charge-points/" + charge_point_uuid)
@@ -80,8 +96,11 @@ class ChargePointDataUpdateCoordinator(ZonneplanDataUpdateCoordinator):
     async def async_update_charge_point_data(self) -> None:
         charge_point = await self._async_get_charge_point_data(self.connection_uuid, self.contract["uuid"])
         if charge_point:
+            contract = charge_point["contracts"][0]
             self.vehicles = charge_point.get("vehicles") or []
-            self.data = charge_point["contracts"][0]
+            self._reconcile_pending_dynamic_charge(contract)
+
+            self.data = contract
             self.async_update_listeners()
 
     def get_vehicle(self, vehicle_uuid: str | None) -> dict | None:
@@ -122,28 +141,100 @@ class ChargePointDataUpdateCoordinator(ZonneplanDataUpdateCoordinator):
 
         await self.async_fetch_charge_point_data()
 
-    async def async_dynamic_charge(self, edited_unit: str | None = None) -> None:
-        if edited_unit:
-            self._last_edited_dynamic_charge_unit = edited_unit
+    def parse_dynamic_charge_datetime(self, value: Any) -> datetime | None:
+        """Parse an API or staged end time; a value without offset is Europe/Amsterdam, like the API expects it back."""
+        parsed = dt_util.parse_datetime(value) if isinstance(value, str) else value
+        if not isinstance(parsed, datetime):
+            return None
 
-        desired_end_time = self.get_data_value("state.dynamic_charging_user_constraints.desired_end_time")
-        desired_percentage = self.get_data_value("state.dynamic_charging_user_constraints.desired_additional_battery_percentage")
-        desired_kilometers = self.get_data_value("state.dynamic_charging_user_constraints.desired_distance_in_kilometers")
+        return parsed.replace(tzinfo=self.zonneplan_api_time_zone) if parsed.tzinfo is None else parsed
 
-        desired_end_datetime = dt_util.parse_datetime(desired_end_time) if isinstance(desired_end_time, str) else None
+    def _api_dynamic_charge_value(self, data: dict | None, path: str) -> Any:
+        """Read a constraint from an arbitrary payload; get_data_value can only read self.data."""
+        value = data
+        for key in path.split("."):
+            if not isinstance(value, dict):
+                return None
+            value = value.get(key)
+
+        return value
+
+    def _dynamic_charge_values_equal(self, path: str, left: Any, right: Any) -> bool:
+        if path == DYNAMIC_CHARGE_END_TIME:
+            return self.parse_dynamic_charge_datetime(left) == self.parse_dynamic_charge_datetime(right)
+
+        return left == right
+
+    def get_dynamic_charge_value(self, path: str) -> Any:
+        """Return the staged value when the user edited this constraint, otherwise the one from the API."""
+        if path in self._pending_dynamic_charge:
+            return self._pending_dynamic_charge[path]
+
+        return self._api_dynamic_charge_value(self.data, path)
+
+    def stage_dynamic_charge_value(self, path: str, value: Any) -> None:
+        """Record a user edit locally; nothing is sent until the apply button is pressed."""
+        api_value = self._api_dynamic_charge_value(self.data, path)
+
+        if self._dynamic_charge_values_equal(path, value, api_value):
+            self._pending_dynamic_charge.pop(path, None)
+            self._pending_dynamic_charge_baseline.pop(path, None)
+        else:
+            self._pending_dynamic_charge[path] = value
+            self._pending_dynamic_charge_baseline[path] = api_value
+
+        self.async_update_listeners()
+
+        # An unavailable apply button says nothing about what it is still waiting for.
+        self._build_dynamic_charge_params(log_level=logging.INFO)
+
+    def has_pending_dynamic_charge_changes(self) -> bool:
+        return bool(self._pending_dynamic_charge)
+
+    def pending_amount_unit(self) -> str | None:
+        """Return the unit the user staged an amount for; the API accepts only one unit per session."""
+        return next(
+            (unit for path, unit in DYNAMIC_CHARGE_AMOUNT_UNITS.items() if path in self._pending_dynamic_charge),
+            None,
+        )
+
+    def discard_dynamic_charge_changes(self) -> None:
+        self._pending_dynamic_charge.clear()
+        self._pending_dynamic_charge_baseline.clear()
+        self.async_update_listeners()
+
+    def _reconcile_pending_dynamic_charge(self, data: dict) -> None:
+        """Drop staged edits the API moved on from: an expired session or a change made in the app wins."""
+        for path, baseline in list(self._pending_dynamic_charge_baseline.items()):
+            if not self._dynamic_charge_values_equal(path, self._api_dynamic_charge_value(data, path), baseline):
+                self._pending_dynamic_charge.pop(path, None)
+                self._pending_dynamic_charge_baseline.pop(path, None)
+
+    def _build_dynamic_charge_params(self, *, log_level: int | None = None) -> dict | None:
+        def reject(message: str) -> None:
+            if log_level is not None:
+                _LOGGER.log(log_level, message)
+
+        desired_end_time = self.get_dynamic_charge_value(DYNAMIC_CHARGE_END_TIME)
+        desired_percentage = self.get_dynamic_charge_value(DYNAMIC_CHARGE_PERCENTAGE)
+        desired_kilometers = self.get_dynamic_charge_value(DYNAMIC_CHARGE_KILOMETERS)
+
+        desired_end_datetime = self.parse_dynamic_charge_datetime(desired_end_time)
         if desired_end_datetime is None:
-            _LOGGER.warning("Can not start a dynamic charge session, the end date is not set.")
-            return  # do nothing when there is no desired end time
-        if desired_end_datetime < dt_util.now() + timedelta(minutes=15):
-            _LOGGER.warning("Can not set the dynamic charge session to end in the past or the next 15 minutes.")
-            return  # do nothing when the desired end time already passed (or is too soon)
+            reject("Can not start a dynamic charge session, the end date is not set.")
+            return None
+        if desired_end_datetime < dt_util.now() + MIN_DYNAMIC_CHARGE_DURATION:
+            reject("Can not set the dynamic charge session to end in the past or the next 15 minutes.")
+            return None
 
         user_constraints = {"desired_end_time": desired_end_datetime.astimezone(self.zonneplan_api_time_zone).strftime("%Y-%m-%d %H:%M:00")}
 
-        if self._last_edited_dynamic_charge_unit == "kilometers" and desired_kilometers:
+        # A staged amount is the user's explicit choice of unit; otherwise fall back to whatever the API still has.
+        pending_unit = self.pending_amount_unit()
+        if pending_unit == "kilometers" and desired_kilometers:
             user_constraints["unit"] = "kilometers"
             user_constraints["value"] = desired_kilometers
-        elif self._last_edited_dynamic_charge_unit == "percentage" and desired_percentage:
+        elif pending_unit == "percentage" and desired_percentage:
             user_constraints["unit"] = "percentage"
             user_constraints["value"] = desired_percentage
         elif desired_kilometers:
@@ -153,18 +244,61 @@ class ChargePointDataUpdateCoordinator(ZonneplanDataUpdateCoordinator):
             user_constraints["unit"] = "percentage"
             user_constraints["value"] = desired_percentage
         else:
-            _LOGGER.warning("Can not set the dynamic charge session, no amount to charge set.")
-            return  # both the percentage and
+            reject("Can not set the dynamic charge session, no amount to charge set.")
+            return None
 
         params = {"user_constraints": user_constraints}
         if self.selected_vehicle_uuid:
             params["vehicle"] = {"vehicle_uuid": self.selected_vehicle_uuid}
+
+        return params
+
+    def dynamic_charge_params_are_valid(self) -> bool:
+        return self._build_dynamic_charge_params() is not None
+
+    async def async_apply_dynamic_charge(self) -> None:
+        params = self._build_dynamic_charge_params(log_level=logging.WARNING)
+        if params is None:
+            return
 
         await self.api.async_post(
             self.connection_uuid,
             "/charge-points/" + self.contract["uuid"] + "/actions/start_dynamic_charging_session",
             params,
         )
+
+        self._pending_dynamic_charge.clear()
+        self._pending_dynamic_charge_baseline.clear()
+
+        self.data["state"]["processing"] = True
+
+        self.async_update_listeners()
+
+        await self.async_fetch_charge_point_data()
+
+    def has_dynamic_charge_schedule(self) -> bool:
+        return self.parse_dynamic_charge_datetime(self._api_dynamic_charge_value(self.data, DYNAMIC_CHARGE_END_TIME)) is not None
+
+    async def async_reset_dynamic_charge(self) -> None:
+        # The app stops a running dynamic session before clearing the planning; mirror that order.
+        # A planning scheduled for later has nothing to stop, so tolerate that rejection and still reset.
+        try:
+            await self.api.async_post(
+                self.connection_uuid,
+                "/charge-points/" + self.contract["uuid"] + "/actions/stop_dynamic_charging_session",
+            )
+        except ZonneplanRateLimitError:
+            raise
+        except ClientResponseError as e:
+            _LOGGER.debug("Could not stop the dynamic charge session before reset (%s); continuing", e.status)
+
+        await self.api.async_post(
+            self.connection_uuid,
+            "/charge-points/" + self.contract["uuid"] + "/actions/reset_schedule",
+        )
+
+        self._pending_dynamic_charge.clear()
+        self._pending_dynamic_charge_baseline.clear()
 
         self.data["state"]["processing"] = True
 

--- a/custom_components/zonneplan_one/datetime.py
+++ b/custom_components/zonneplan_one/datetime.py
@@ -91,14 +91,12 @@ class ZonneplanChargePointDateTime(ChargePointEntity, CoordinatorEntity[ChargePo
         return "processing" not in state
 
     @property
-    def native_value(self) -> datetime:
-        value = self.coordinator.get_data_value(self.entity_description.key.format(install_index=self._install_index))
-        return dt_util.parse_datetime(value) if isinstance(value, str) else None
+    def _value_path(self) -> str:
+        return self.entity_description.key.format(install_index=self._install_index)
+
+    @property
+    def native_value(self) -> datetime | None:
+        return self.coordinator.parse_dynamic_charge_datetime(self.coordinator.get_dynamic_charge_value(self._value_path))
 
     async def async_set_value(self, value: datetime) -> None:
-        self.coordinator.set_data_value(
-            self.entity_description.key.format(install_index=self._install_index),
-            dt_util.as_local(value).isoformat(),
-        )
-
-        await self.coordinator.async_dynamic_charge()
+        self.coordinator.stage_dynamic_charge_value(self._value_path, dt_util.as_local(value).isoformat())

--- a/custom_components/zonneplan_one/number.py
+++ b/custom_components/zonneplan_one/number.py
@@ -212,11 +212,14 @@ class ZonneplanReserveDischargeNumber(BatteryEntity, CoordinatorEntity, NumberEn
         await self.coordinator.async_set_reserve_discharge(int(value))
 
 
-class ZonneplanDynamicChargeDesiredPercentageNumber(ChargePointEntity, CoordinatorEntity, NumberEntity):
+class ZonneplanDynamicChargeAmountNumber(ChargePointEntity, CoordinatorEntity, NumberEntity):
+    """Desired charge amount, staged locally until the apply button is pressed."""
+
     coordinator: ChargePointDataUpdateCoordinator
     _connection_uuid: str
     _install_index: int
     _key: str
+    _unit: str
     entity_description: ZonneplanNumberEntityDescription
 
     def __init__(
@@ -250,88 +253,43 @@ class ZonneplanDynamicChargeDesiredPercentageNumber(ChargePointEntity, Coordinat
         if not state or not state["connectivity_state"]:
             return False
 
-        return "processing" not in state
+        if "processing" in state:
+            return False
+
+        # Only one amount can be sent, so staging one unit locks the other until it is applied or discarded.
+        pending_unit = self.coordinator.pending_amount_unit()
+
+        return pending_unit is None or pending_unit == self._unit
 
     @property
-    def native_value(self) -> float:
-        value = self.coordinator.get_data_value(
-            self.entity_description.key.format(install_index=self._install_index),
-        )
-        if not value or not isinstance(value, int):
-            value = 0
+    def _value_path(self) -> str:
+        return self.entity_description.key.format(install_index=self._install_index)
+
+    @property
+    def native_value(self) -> float | None:
+        value = self.coordinator.get_dynamic_charge_value(self._value_path)
+        if not isinstance(value, (int, float)) or not value:
+            return None
 
         return value * (self.entity_description.value_factor or 1)
 
     async def async_set_native_value(self, value: float) -> None:
-        self.coordinator.set_data_value(
-            self.entity_description.key.format(install_index=self._install_index),
+        self.coordinator.stage_dynamic_charge_value(
+            self._value_path,
             int(value / (self.entity_description.value_factor or 1)),
         )
 
-        await self.coordinator.async_dynamic_charge(edited_unit="percentage")
+
+class ZonneplanDynamicChargeDesiredPercentageNumber(ZonneplanDynamicChargeAmountNumber):
+    _unit = "percentage"
 
 
-class ZonneplanDynamicChargeDesiredKilometers(ChargePointEntity, CoordinatorEntity, NumberEntity):
-    coordinator: ChargePointDataUpdateCoordinator
-    _connection_uuid: str
-    _install_index: int
-    _key: str
-    entity_description: ZonneplanNumberEntityDescription
-
-    def __init__(
-        self,
-        connection_uuid: str,
-        _key: str,
-        coordinator: ChargePointDataUpdateCoordinator,
-        install_index: int,
-        description: ZonneplanNumberEntityDescription,
-    ) -> None:
-        """Initialize the button."""
-        super().__init__(coordinator)
-        self._connection_uuid = connection_uuid
-        self._install_index = install_index
-        self._key = _key
-        self.entity_description = description
-
-    @property
-    def unique_id(self) -> str | None:
-        """Return a unique ID."""
-        return self.install_uuid + "_" + self._key
-
-    @property
-    def available(self) -> bool:
-        """Return if entity is available."""
-        if not self.coordinator.data or not self.coordinator.last_update_success:
-            return False
-
-        state = self.coordinator.get_data_value("state")
-
-        if not state or not state["connectivity_state"]:
-            return False
-
-        return "processing" not in state
+class ZonneplanDynamicChargeDesiredKilometers(ZonneplanDynamicChargeAmountNumber):
+    _unit = "kilometers"
 
     @property
     def native_max_value(self) -> float:
         return self.coordinator.get_max_desired_kilometers() or self.entity_description.native_max_value
-
-    @property
-    def native_value(self) -> float:
-        value = self.coordinator.get_data_value(
-            self.entity_description.key.format(install_index=self._install_index),
-        )
-        if not value or not isinstance(value, int):
-            value = 0
-
-        return value * (self.entity_description.value_factor or 1)
-
-    async def async_set_native_value(self, value: float) -> None:
-        self.coordinator.set_data_value(
-            self.entity_description.key.format(install_index=self._install_index),
-            int(value / (self.entity_description.value_factor or 1)),
-        )
-
-        await self.coordinator.async_dynamic_charge(edited_unit="kilometers")
 
 
 CHARGE_POINT_NUMBER_ENTITY_CLASSES = {

--- a/custom_components/zonneplan_one/strings.json
+++ b/custom_components/zonneplan_one/strings.json
@@ -328,6 +328,87 @@
       },
       "energy_produced_sum_this_year": {
         "name": "Net production this year"
+      },
+      "installation_wp": {
+        "name": "Installation Wp"
+      },
+      "panel_wp": {
+        "name": "Panel Wp"
+      },
+      "panel_count": {
+        "name": "Panel count"
+      },
+      "inverter_model_name": {
+        "name": "Inverter model name"
+      },
+      "inverter_firmware_version": {
+        "name": "Inverter firmware version"
+      },
+      "module_firmware_version": {
+        "name": "Module firmware version"
+      },
+      "electricity_delivery_costs_today_excl_tax": {
+        "name": "Electricity delivery costs today (excl. tax)"
+      },
+      "electricity_delivery_costs_this_month_excl_tax": {
+        "name": "Electricity delivery costs this month (excl. tax)"
+      },
+      "electricity_delivery_costs_this_year_excl_tax": {
+        "name": "Electricity delivery costs this year (excl. tax)"
+      },
+      "electricity_production_costs_today_excl_tax": {
+        "name": "Electricity production costs today (excl. tax)"
+      },
+      "electricity_production_costs_this_month_excl_tax": {
+        "name": "Electricity production costs this month (excl. tax)"
+      },
+      "electricity_production_costs_this_year_excl_tax": {
+        "name": "Electricity production costs this year (excl. tax)"
+      },
+      "electricity_delivery_price_per_unit_today_excl_tax": {
+        "name": "Electricity delivery price per unit today (excl. tax)"
+      },
+      "electricity_delivery_price_per_unit_this_month_excl_tax": {
+        "name": "Electricity delivery price per unit this month (excl. tax)"
+      },
+      "electricity_delivery_price_per_unit_this_year_excl_tax": {
+        "name": "Electricity delivery price per unit this year (excl. tax)"
+      },
+      "electricity_production_price_per_unit_today_excl_tax": {
+        "name": "Electricity production price per unit today (excl. tax)"
+      },
+      "electricity_production_price_per_unit_this_month_excl_tax": {
+        "name": "Electricity production price per unit this month (excl. tax)"
+      },
+      "electricity_production_price_per_unit_this_year_excl_tax": {
+        "name": "Electricity production price per unit this year (excl. tax)"
+      },
+      "gas_delivery_costs_today_excl_tax": {
+        "name": "Gas delivery costs today (excl. tax)"
+      },
+      "host_device_model_name": {
+        "name": "Host device model name"
+      },
+      "charge_point_model_name": {
+        "name": "Charge point model name"
+      },
+      "delivery_costs_this_month_excl_tax": {
+        "name": "Net delivery costs this month (excl. tax)"
+      },
+      "delivery_costs_this_year_excl_tax": {
+        "name": "Net delivery costs this year (excl. tax)"
+      },
+      "production_costs_this_year_excl_tax": {
+        "name": "Net production costs this year (excl. tax)"
+      },
+      "charge_point_dynamic_desired_additional_battery_percentage": {
+        "name": "Charge point dynamic load desired percentage"
+      },
+      "production_costs_this_month_excl_tax": {
+        "name": "Net production costs this month (excl. tax)"
+      },
+      "backup_power_usable_capacity_wh": {
+        "name": "Backup power usable capacity"
       }
     },
     "binary_sensor": {
@@ -390,6 +471,12 @@
       },
       "charge_point_dynamic_charging_flex_suppressed": {
         "name": "Charge point dynamic charging flex suppressed"
+      },
+      "charge_on_solar_enabled": {
+        "name": "Charge on solar enabled"
+      },
+      "backup_power_active": {
+        "name": "Backup power active"
       }
     },
     "button": {
@@ -399,8 +486,14 @@
       "stop_charge": {
         "name": "Stop charge"
       },
-      "dynamic_charge": {
-        "name": "Dynamic charge (percentage)"
+      "apply_dynamic_charge": {
+        "name": "Apply changes"
+      },
+      "discard_dynamic_charge": {
+        "name": "Cancel changes"
+      },
+      "reset_dynamic_charge": {
+        "name": "Delete planning"
       }
     },
     "number": {
@@ -415,11 +508,14 @@
       },
       "charge_point_dynamic_desired_additional_battery_percentage": {
         "name": "Desired percentage"
+      },
+      "reserve_discharge_cutoff_wh": {
+        "name": "Reserve discharge cutoff"
       }
     },
     "datetime": {
       "charge_point_dynamic_load_desired_end_time": {
-        "name": "Desired end time"
+        "name": "Departure time"
       }
     },
     "select": {
@@ -432,7 +528,7 @@
         }
       },
       "charge_point_vehicle": {
-        "name": "Car"
+        "name": "Selected car"
       }
     }
   },

--- a/custom_components/zonneplan_one/translations/en.json
+++ b/custom_components/zonneplan_one/translations/en.json
@@ -31,12 +31,523 @@
     }
   },
   "entity": {
+    "sensor": {
+      "usage": {
+        "name": "Current usage"
+      },
+      "usage_measured_at": {
+        "name": "Current usage measured at"
+      },
+      "sustainability_score": {
+        "name": "Sustainability score"
+      },
+      "current_tariff_group": {
+        "name": "Current tariff group"
+      },
+      "current_electricity_tariff": {
+        "name": "Current electricity tariff"
+      },
+      "current_quarter_hourly_electricity_tariff": {
+        "name": "Current quarter hourly electricity tariff"
+      },
+      "current_hourly_electricity_tariff": {
+        "name": "Current hourly electricity tariff"
+      },
+      "current_gas_tariff": {
+        "name": "Current gas tariff"
+      },
+      "next_gas_tariff": {
+        "name": "Next gas tariff"
+      },
+      "status_message": {
+        "name": "Status message"
+      },
+      "status_tip": {
+        "name": "Status tip"
+      },
+      "forecast_tariff_hour_1": {
+        "name": "Forecast tariff hour 1"
+      },
+      "forecast_tariff_hour_2": {
+        "name": "Forecast tariff hour 2"
+      },
+      "forecast_tariff_hour_3": {
+        "name": "Forecast tariff hour 3"
+      },
+      "forecast_tariff_hour_4": {
+        "name": "Forecast tariff hour 4"
+      },
+      "forecast_tariff_hour_5": {
+        "name": "Forecast tariff hour 5"
+      },
+      "forecast_tariff_hour_6": {
+        "name": "Forecast tariff hour 6"
+      },
+      "forecast_tariff_hour_7": {
+        "name": "Forecast tariff hour 7"
+      },
+      "forecast_tariff_hour_8": {
+        "name": "Forecast tariff hour 8"
+      },
+      "forecast_tariff_group_hour_1": {
+        "name": "Forecast tariff group hour 1"
+      },
+      "forecast_tariff_group_hour_2": {
+        "name": "Forecast tariff group hour 2"
+      },
+      "forecast_tariff_group_hour_3": {
+        "name": "Forecast tariff group hour 3"
+      },
+      "forecast_tariff_group_hour_4": {
+        "name": "Forecast tariff group hour 4"
+      },
+      "forecast_tariff_group_hour_5": {
+        "name": "Forecast tariff group hour 5"
+      },
+      "forecast_tariff_group_hour_6": {
+        "name": "Forecast tariff group hour 6"
+      },
+      "forecast_tariff_group_hour_7": {
+        "name": "Forecast tariff group hour 7"
+      },
+      "forecast_tariff_group_hour_8": {
+        "name": "Forecast tariff group hour 8"
+      },
+      "yield_total": {
+        "name": "Yield total"
+      },
+      "last_measured_value": {
+        "name": "Last measured value"
+      },
+      "first_measured": {
+        "name": "First measured"
+      },
+      "last_measured": {
+        "name": "Last measured"
+      },
+      "powerplay_total": {
+        "name": "Powerplay total"
+      },
+      "powerplay_today": {
+        "name": "Powerplay today"
+      },
+      "yield_today": {
+        "name": "Yield today"
+      },
+      "electricity_consumption_today": {
+        "name": "Electricity consumption today"
+      },
+      "electricity_returned_today": {
+        "name": "Electricity returned today"
+      },
+      "electricity_delivery_costs_today": {
+        "name": "Electricity delivery costs today"
+      },
+      "electricity_delivery_costs_this_month": {
+        "name": "Electricity delivery costs this month"
+      },
+      "electricity_delivery_costs_this_year": {
+        "name": "Electricity delivery costs this year"
+      },
+      "electricity_production_costs_today": {
+        "name": "Electricity production costs today"
+      },
+      "electricity_production_costs_this_month": {
+        "name": "Electricity production costs this month"
+      },
+      "electricity_production_costs_this_year": {
+        "name": "Electricity production costs this year"
+      },
+      "electricity_delivery_price_per_unit_today": {
+        "name": "Electricity delivery price per unit today"
+      },
+      "electricity_delivery_price_per_unit_this_month": {
+        "name": "Electricity delivery price per unit this month"
+      },
+      "electricity_delivery_price_per_unit_this_year": {
+        "name": "Electricity delivery price per unit this year"
+      },
+      "electricity_production_price_per_unit_today": {
+        "name": "Electricity production price per unit today"
+      },
+      "electricity_production_price_per_unit_this_month": {
+        "name": "Electricity production price per unit this month"
+      },
+      "electricity_production_price_per_unit_this_year": {
+        "name": "Electricity production price per unit this year"
+      },
+      "gas_consumption_today": {
+        "name": "Gas consumption today"
+      },
+      "gas_delivery_costs_today": {
+        "name": "Gas delivery costs today"
+      },
+      "electricity_consumption": {
+        "name": "Electricity consumption"
+      },
+      "electricity_production": {
+        "name": "Electricity production"
+      },
+      "electricity_average": {
+        "name": "Electricity average"
+      },
+      "electricity_first_measured": {
+        "name": "Electricity first measured"
+      },
+      "electricity_last_measured": {
+        "name": "Electricity last measured"
+      },
+      "electricity_last_measured_production": {
+        "name": "Electricity last measured production"
+      },
+      "gas_first_measured": {
+        "name": "Gas first measured"
+      },
+      "gas_last_measured": {
+        "name": "Gas last measured"
+      },
+      "dsmr_version": {
+        "name": "Dsmr version"
+      },
+      "battery_state": {
+        "name": "Battery state"
+      },
+      "battery_control_mode": {
+        "name": "Battery control mode"
+      },
+      "state_of_charge": {
+        "name": "Percentage"
+      },
+      "power": {
+        "name": "Power"
+      },
+      "inverter_state": {
+        "name": "Inverter state"
+      },
+      "total_earned": {
+        "name": "Total"
+      },
+      "result_this_year": {
+        "name": "Result this year"
+      },
+      "result_last_year": {
+        "name": "Result last year"
+      },
+      "total_day": {
+        "name": "Today"
+      },
+      "average_day": {
+        "name": "Average day"
+      },
+      "result_this_month": {
+        "name": "Result this month"
+      },
+      "result_last_month": {
+        "name": "Result last month"
+      },
+      "delivery_today": {
+        "name": "Delivery today"
+      },
+      "production_today": {
+        "name": "Production today"
+      },
+      "battery_cycles": {
+        "name": "Battery cycles"
+      },
+      "charge_point_state": {
+        "name": "Charge point state"
+      },
+      "charge_point_power": {
+        "name": "Charge point power"
+      },
+      "charge_point_energy_delivered_session": {
+        "name": "Charge point energy delivered session"
+      },
+      "charge_point_session_cost": {
+        "name": "Charge point session cost"
+      },
+      "charge_point_cost_total": {
+        "name": "Charge point cost total"
+      },
+      "charge_point_session_flex_result": {
+        "name": "Charge point session flex result"
+      },
+      "charge_point_session_average_costs": {
+        "name": "Charge point session average costs"
+      },
+      "charge_point_next_schedule_start": {
+        "name": "Charge point next schedule start"
+      },
+      "charge_point_next_schedule_end": {
+        "name": "Charge point next schedule end"
+      },
+      "charge_point_dynamic_load_balancing_health": {
+        "name": "Charge point dynamic load balancing health"
+      },
+      "charge_point_start_mode": {
+        "name": "Charge point start mode"
+      },
+      "charge_point_dynamic_load_desired_distance": {
+        "name": "Charge point dynamic load desired distance"
+      },
+      "charge_point_dynamic_load_desired_end_time": {
+        "name": "Charge point dynamic load desired end time"
+      },
+      "charge_point_session_start_time": {
+        "name": "Charge point session start time"
+      },
+      "charge_point_session_charged_distance": {
+        "name": "Charge point session charged distance"
+      },
+      "delivery_costs_this_month": {
+        "name": "Net delivery costs this month"
+      },
+      "delivery_costs_this_year": {
+        "name": "Net delivery costs this year"
+      },
+      "production_costs_this_month": {
+        "name": "Net production costs this month"
+      },
+      "production_costs_this_year": {
+        "name": "Net production costs this year"
+      },
+      "energy_delivered_sum_today": {
+        "name": "Net delivery today"
+      },
+      "energy_delivered_sum_this_month": {
+        "name": "Net delivery this month"
+      },
+      "energy_delivered_sum_this_year": {
+        "name": "Net delivery this year"
+      },
+      "energy_produced_sum_today": {
+        "name": "Net production today"
+      },
+      "energy_produced_sum_this_month": {
+        "name": "Net production this month"
+      },
+      "energy_produced_sum_this_year": {
+        "name": "Net production this year"
+      },
+      "installation_wp": {
+        "name": "Installation Wp"
+      },
+      "panel_wp": {
+        "name": "Panel Wp"
+      },
+      "panel_count": {
+        "name": "Panel count"
+      },
+      "inverter_model_name": {
+        "name": "Inverter model name"
+      },
+      "inverter_firmware_version": {
+        "name": "Inverter firmware version"
+      },
+      "module_firmware_version": {
+        "name": "Module firmware version"
+      },
+      "electricity_delivery_costs_today_excl_tax": {
+        "name": "Electricity delivery costs today (excl. tax)"
+      },
+      "electricity_delivery_costs_this_month_excl_tax": {
+        "name": "Electricity delivery costs this month (excl. tax)"
+      },
+      "electricity_delivery_costs_this_year_excl_tax": {
+        "name": "Electricity delivery costs this year (excl. tax)"
+      },
+      "electricity_production_costs_today_excl_tax": {
+        "name": "Electricity production costs today (excl. tax)"
+      },
+      "electricity_production_costs_this_month_excl_tax": {
+        "name": "Electricity production costs this month (excl. tax)"
+      },
+      "electricity_production_costs_this_year_excl_tax": {
+        "name": "Electricity production costs this year (excl. tax)"
+      },
+      "electricity_delivery_price_per_unit_today_excl_tax": {
+        "name": "Electricity delivery price per unit today (excl. tax)"
+      },
+      "electricity_delivery_price_per_unit_this_month_excl_tax": {
+        "name": "Electricity delivery price per unit this month (excl. tax)"
+      },
+      "electricity_delivery_price_per_unit_this_year_excl_tax": {
+        "name": "Electricity delivery price per unit this year (excl. tax)"
+      },
+      "electricity_production_price_per_unit_today_excl_tax": {
+        "name": "Electricity production price per unit today (excl. tax)"
+      },
+      "electricity_production_price_per_unit_this_month_excl_tax": {
+        "name": "Electricity production price per unit this month (excl. tax)"
+      },
+      "electricity_production_price_per_unit_this_year_excl_tax": {
+        "name": "Electricity production price per unit this year (excl. tax)"
+      },
+      "gas_delivery_costs_today_excl_tax": {
+        "name": "Gas delivery costs today (excl. tax)"
+      },
+      "host_device_model_name": {
+        "name": "Host device model name"
+      },
+      "charge_point_model_name": {
+        "name": "Charge point model name"
+      },
+      "delivery_costs_this_month_excl_tax": {
+        "name": "Net delivery costs this month (excl. tax)"
+      },
+      "delivery_costs_this_year_excl_tax": {
+        "name": "Net delivery costs this year (excl. tax)"
+      },
+      "production_costs_this_year_excl_tax": {
+        "name": "Net production costs this year (excl. tax)"
+      },
+      "charge_point_dynamic_desired_additional_battery_percentage": {
+        "name": "Charge point dynamic load desired percentage"
+      },
+      "production_costs_this_month_excl_tax": {
+        "name": "Net production costs this month (excl. tax)"
+      },
+      "backup_power_usable_capacity_wh": {
+        "name": "Backup power usable capacity"
+      }
+    },
+    "binary_sensor": {
+      "dynamic_charging_enabled": {
+        "name": "Powerplay"
+      },
+      "dynamic_load_balancing_enabled": {
+        "name": "Dynamic load balancing enabled"
+      },
+      "dynamic_load_balancing_overload_active": {
+        "name": "Dynamic load balancing overload active"
+      },
+      "manual_control_enabled": {
+        "name": "Manual control enabled"
+      },
+      "self_consumption_enabled": {
+        "name": "Self consumption enabled"
+      },
+      "home_optimization_enabled": {
+        "name": "Home optimization enabled"
+      },
+      "home_optimization_active": {
+        "name": "Home optimization active"
+      },
+      "grid_congestion_active": {
+        "name": "Grid congestion active"
+      },
+      "powerplay_enabled": {
+        "name": "Powerplay enabled"
+      },
+      "power_limit_active": {
+        "name": "Power limit active"
+      },
+      "charge_point_connectivity_state": {
+        "name": "Charge point connectivity state"
+      },
+      "charge_point_can_charge": {
+        "name": "Charge point can charge"
+      },
+      "charge_point_can_schedule": {
+        "name": "Charge point can schedule"
+      },
+      "charge_point_charging_manually": {
+        "name": "Charge point charging manually"
+      },
+      "charge_point_charging_automatically": {
+        "name": "Charge point charging automatically"
+      },
+      "charge_point_plug_and_charge": {
+        "name": "Charge point plug and charge"
+      },
+      "charge_point_overload_protection_active": {
+        "name": "Charge point overload protection active"
+      },
+      "charge_point_dynamic_charging_enabled": {
+        "name": "Charge point dynamic charging enabled"
+      },
+      "charge_point_dynamic_charging_flex_enabled": {
+        "name": "Charge point dynamic charging flex enabled"
+      },
+      "charge_point_dynamic_charging_flex_suppressed": {
+        "name": "Charge point dynamic charging flex suppressed"
+      },
+      "charge_on_solar_enabled": {
+        "name": "Charge on solar enabled"
+      },
+      "backup_power_active": {
+        "name": "Backup power active"
+      }
+    },
+    "button": {
+      "start_charge": {
+        "name": "Start charge"
+      },
+      "stop_charge": {
+        "name": "Stop charge"
+      },
+      "apply_dynamic_charge": {
+        "name": "Apply changes"
+      },
+      "discard_dynamic_charge": {
+        "name": "Cancel changes"
+      },
+      "reset_dynamic_charge": {
+        "name": "Delete planning"
+      }
+    },
+    "number": {
+      "max_discharge_power": {
+        "name": "Max discharge power (Home optimization)"
+      },
+      "max_charge_power": {
+        "name": "Max charge power (Home optimization)"
+      },
+      "charge_point_dynamic_load_desired_distance": {
+        "name": "Desired distance"
+      },
+      "charge_point_dynamic_desired_additional_battery_percentage": {
+        "name": "Desired percentage"
+      },
+      "reserve_discharge_cutoff_wh": {
+        "name": "Reserve discharge cutoff"
+      }
+    },
+    "datetime": {
+      "charge_point_dynamic_load_desired_end_time": {
+        "name": "Departure time"
+      }
+    },
     "select": {
       "battery_control_mode": {
+        "name": "Battery control mode",
         "state": {
           "dynamic_charging": "Dynamic charging",
           "home_optimization": "Home optimization",
           "self_consumption": "Self consumption"
+        }
+      },
+      "charge_point_vehicle": {
+        "name": "Selected car"
+      }
+    }
+  },
+  "services": {
+    "fetch_statistics": {
+      "name": "Fetch history from Zonneplan API",
+      "description": "Refetch statistics from a given date until now, repairing any gaps or incorrect historical values.",
+      "fields": {
+        "endpoint": {
+          "name": "Endpoint",
+          "description": "The data endpoint to refetch statistics for (electricity or gas)."
+        },
+        "start_date": {
+          "name": "Start date",
+          "description": "The date to start refetching from. Accepted formats: YYYYMMDD or YYYY-MM-DD."
+        },
+        "connection_uuid": {
+          "name": "Connection UUID",
+          "description": "Optionally limit the refetch to a specific connection UUID. If omitted, all matching connections are updated (see last part of statistics_id: `zonneplan_one:electricity_delivered_xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx`)."
         }
       }
     }

--- a/custom_components/zonneplan_one/translations/nl.json
+++ b/custom_components/zonneplan_one/translations/nl.json
@@ -443,7 +443,7 @@
       "production_costs_this_month": {
         "name": "Netto teruggeleverd deze maand"
       },
-      "production_costs__this_monthexcl_tax": {
+      "production_costs_this_month_excl_tax": {
         "name": "Netto teruggeleverd deze maand (excl. btw)"
       },
       "production_costs_this_year": {
@@ -469,6 +469,9 @@
       },
       "energy_produced_sum_this_year": {
         "name": "Netto teruggeleverd dit jaar"
+      },
+      "charge_point_dynamic_desired_additional_battery_percentage": {
+        "name": "Laadpaal dynamic load gewenst percentage"
       }
     },
     "binary_sensor": {
@@ -546,8 +549,14 @@
       "stop_charge": {
         "name": "Stop laden"
       },
-      "dynamic_charge": {
-        "name": "Start laden (percentage)"
+      "apply_dynamic_charge": {
+        "name": "Wijzigingen toepassen"
+      },
+      "discard_dynamic_charge": {
+        "name": "Wijzigingen verwerpen"
+      },
+      "reset_dynamic_charge": {
+        "name": "Laadplan verwijderen"
       }
     },
     "number": {
@@ -561,15 +570,15 @@
         "name": "Minimum noodstroom reserve"
       },
       "charge_point_dynamic_load_desired_distance": {
-        "name": "Gewenste afstand"
+        "name": "Gewenst aantal kilometers"
       },
       "charge_point_dynamic_desired_additional_battery_percentage": {
-        "name": "Gewenst pecentage"
+        "name": "Gewenst percentage"
       }
     },
     "datetime": {
       "charge_point_dynamic_load_desired_end_time": {
-        "name": "Gewenste eindtijd"
+        "name": "Gewenste vertrektijd"
       }
     },
     "select": {
@@ -582,7 +591,7 @@
         }
       },
       "charge_point_vehicle": {
-        "name": "Auto"
+        "name": "Geselecteerde auto"
       }
     }
   }


### PR DESCRIPTION
Editing a dynamic charge constraint POSTed a new session on every change, so bumping the desired distance from 100 to 110 km fired ten API calls.

The number and datetime entities now stage their value in a pending buffer on the charge point coordinator instead of sending it straight to the API. An apply and a discard button flush or drop that buffer, and both are only available while something is staged.

After every fetch the staged values are reconciled against the new payload: an edit whose API value moved on is dropped, so an expired session empties the fields and a change made in the Zonneplan app takes over, while an unchanged API value leaves the local edit alone.

Only one unit can be sent per session, so staging a distance greys out the percentage and vice versa; discarding is the way back.

<img width="404" height="528" alt="Jul-30-2026 09-27-25" src="https://github.com/user-attachments/assets/f32892ef-12df-4abc-a1b1-ae9370afadfd" />
